### PR TITLE
Set deterministic history (based on tab name) for fish/bash/zsh

### DIFF
--- a/common/tab-api/src/config.rs
+++ b/common/tab-api/src/config.rs
@@ -66,6 +66,16 @@ pub fn config_path() -> Result<PathBuf> {
     Ok(path)
 }
 
+pub fn history_path(shell: &str, name: &str) -> Result<PathBuf> {
+    let mut path = dotdir_path()?;
+    path.push("history");
+
+    let filename = format!("history-{}-{}.txt", shell, name);
+    path.push(filename);
+
+    Ok(path)
+}
+
 pub fn load_config() -> anyhow::Result<Config> {
     let path = config_path()?;
 


### PR DESCRIPTION
Resolves #23,

Introduces #30 - Zsh support is not fully working yet.  This may require documentation on how to fix for users.