### PR TITLE
Select the `any` tab if no arguments are provided

### DIFF
--- a/tab-cli/src/lib.rs
+++ b/tab-cli/src/lib.rs
@@ -66,7 +66,7 @@ async fn main_async(matches: ArgMatches<'_>) -> anyhow::Result<()> {
     } else if let Some(tab) = close_tab {
         tx.send(MainRecv::CloseTab(tab.to_string())).await?;
     } else {
-        tx.send(MainRecv::SelectInteractive).await?;
+        panic!("unsupported command line options")
     }
 
     wait_for_shutdown(rx_shutdown).await;

--- a/tab/src/cli.rs
+++ b/tab/src/cli.rs
@@ -73,6 +73,7 @@ fn app() -> App<'static, 'static> {
                 .help("switches to the provided tab")
                 .required(false)
                 .value_name("TAB")
+                .default_value("any/")
                 .conflicts_with_all(&["CLOSE-TAB", "LIST", "SHUTDOWN"])
                 .index(1),
         )


### PR DESCRIPTION
Resolves #65 and #72