### PR TITLE
Add a timeout in case an integration test blocks on the read

### DIFF
--- a/tab-daemon/src/service/cli.rs
+++ b/tab-daemon/src/service/cli.rs
@@ -208,11 +208,16 @@ impl CliService {
             }
             CliRecv::Retask(from, to) => {
                 info!("acknowledging retask from {:?} to {:?}, updating subscriptions & requesting scrollback", from, to);
+
                 tx_websocket.send(Response::Retask(to)).await?;
+                time::delay_for(Duration::from_millis(10)).await;
+
                 tx_subscription
                     .send(Subscription::Unsubscribe(from))
                     .await?;
                 tx_subscription.send(Subscription::Subscribe(to)).await?;
+                time::delay_for(Duration::from_millis(10)).await;
+
                 tx_daemon.send(CliSend::RequestScrollback(to)).await?;
             }
         }


### PR DESCRIPTION
- Override the TAB and TAB_ID vars for the invoked test
- Fix a synchronization bug with Retask, that caused scrollback not to be echoed.  This was causing the switch test to time out on github actions.