### PR TITLE
Support nested workspaces - a method for lateral navigation between workspaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1309,7 +1309,7 @@ dependencies = [
  "snailquote",
  "strip-ansi-escapes",
  "tab-api 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "tab-command 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tab-command",
  "tab-daemon 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tab-pty 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile",
@@ -1370,26 +1370,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-test",
-]
-
-[[package]]
-name = "tab-command"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "752807704d1f25d5824d1c48b5b31af897239c2b8409dbe73eef0430ddbc391e"
-dependencies = [
- "anyhow",
- "clap",
- "crossterm",
- "lifeline",
- "log",
- "serde",
- "serde_yaml",
- "simplelog",
- "tab-api 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "tab-websocket 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,6 @@ members = [
 
 # tab-api = { path = './common/tab-api/' }
 # tab-websocket = { path = './common/tab-websocket/' }
-# tab-command = { path = './tab-command/' }
+tab-command = { path = './tab-command/' }
 # tab-daemon = { path = './tab-daemon/' }
 # tab-pty = { path = './tab-pty/' }

--- a/RELEASE-CHECKLIST.md
+++ b/RELEASE-CHECKLIST.md
@@ -1,14 +1,15 @@
-1) Update all dependencies to the latest with `cargo update`, and run `cargo test --release`
-1) For each crate, in the following list, check for changes since the last release, and publish to crates.io.  Also include any crates with entries in ./Cargo.toml's patch section.
+1) Document all new features in README.md
+2) Update all dependencies to the latest with `cargo update`, and run `cargo test --release`
+3) For each crate, in the following list, check for changes since the last release, and publish to crates.io.  Also include any crates with entries in ./Cargo.toml's patch section.
    1) tab-api
    2) tab-websocket
    3) tab-command
    4) tab-daemon
    5) tab-pty
    6) tab-pty-process
-2) Remove any cargo patches in `./Cargo.toml`.
-3) Update `tab/Cargo.toml` to use the released crates.
-4) Update `tab/Cargo.toml` with the new release version.
-5) Open a PR, and merge to master.
-6) Check that the Github Actions workflow on master succeeds.
-7) Create a Github Release on master, and monitor the progress.
+4) Remove any cargo patches in `./Cargo.toml`.
+5) Update `tab/Cargo.toml` to use the released crates.
+6) Update `tab/Cargo.toml` with the new release version.
+7) Open a PR, and merge to master.
+8) Check that the Github Actions workflow on master succeeds.
+9) Create a Github Release on master, and monitor the progress.

--- a/tab-command/src/service/workspace.rs
+++ b/tab-command/src/service/workspace.rs
@@ -146,6 +146,14 @@ fn load_items(path: &Path, workspace: &Workspace, target: &mut LoaderState) -> a
                     if let Config::Repo(repo) = repo {
                         target.repos.push((repo_path, repo));
                     }
+                } else if repo_path.exists() {
+                    let tab = WorkspaceTab {
+                        name: normalize_name(repo.repo.as_str()),
+                        directory: repo_path,
+                        doc: "".to_string(),
+                    };
+
+                    target.tabs.push(tab);
                 }
             }
 
@@ -160,7 +168,6 @@ fn load_items(path: &Path, workspace: &Workspace, target: &mut LoaderState) -> a
                     name: normalize_name(tab.tab.as_str()),
                     directory,
                     doc: tab.doc.as_ref().unwrap_or(&"".to_string()).clone(),
-                    // command: tab.command.clone(),
                 };
 
                 target.tabs.push(tab);

--- a/tab-command/src/state/workspace.rs
+++ b/tab-command/src/state/workspace.rs
@@ -36,16 +36,24 @@ pub enum Config {
 /// The workspace root configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Workspace {
-    pub workspace: Vec<WorkspaceItem>,
+    pub tab: Option<String>,
     pub doc: Option<String>,
+    pub workspace: Vec<WorkspaceItem>,
 }
 
 /// An item within the workspace configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum WorkspaceItem {
+    Workspace(WorkspaceLink),
     Repo(WorkspaceRepoLink),
     Tab(Tab),
+}
+
+/// A link to a child workspace, from the workspace root.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkspaceLink {
+    pub workspace: String,
 }
 
 /// A link to a repository within the workspace, from the workspace root.


### PR DESCRIPTION
Add support for nested workspaces, and links from a workspace in your home directory to child workspaces.

- When the user is within a workspace, tab will render all repo, workspace, and tab literals defined in the workspace config.
- Tab will search for workspaces up to the root directory.
- When a workspace contains a repo link to an existing directory, but no tab.yml exists there, a tab will be rendered with the directory name and working dir.

Resolves #138 
Resolves #148 