### PR TITLE
Add configurable shells and environment variables

### DIFF
--- a/common/tab-api/src/tab.rs
+++ b/common/tab-api/src/tab.rs
@@ -2,7 +2,7 @@
 
 use lifeline::impl_storage_clone;
 use serde::{Deserialize, Serialize};
-use std::fmt::Display;
+use std::{collections::HashMap, fmt::Display};
 
 pub fn normalize_name(name: &str) -> String {
     let name = name.to_string().trim().to_string();
@@ -34,6 +34,7 @@ pub struct TabMetadata {
     pub id: TabId,
     pub name: String,
     pub dimensions: (u16, u16),
+    pub env: HashMap<String, String>,
     pub shell: String,
     pub dir: String,
 }
@@ -44,6 +45,7 @@ impl TabMetadata {
             id,
             name: create.name,
             dimensions: create.dimensions,
+            env: create.env,
             shell: create.shell,
             dir: create.dir,
         }
@@ -55,6 +57,7 @@ impl TabMetadata {
 pub struct CreateTabMetadata {
     pub name: String,
     pub dimensions: (u16, u16),
+    pub env: HashMap<String, String>,
     pub shell: String,
     pub dir: String,
 }

--- a/tab-command/src/bus/tab.rs
+++ b/tab-command/src/bus/tab.rs
@@ -341,7 +341,7 @@ impl TabBus {
 
         if let Some(workspace) = workspace {
             for tab in workspace.into_iter() {
-                tabs.push((tab.name, tab.doc));
+                tabs.push((tab.name, tab.doc.unwrap_or_else(|| "".to_string())));
             }
         }
 

--- a/tab-command/src/state/workspace.rs
+++ b/tab-command/src/state/workspace.rs
@@ -129,6 +129,8 @@ impl Default for TabOptions {
 }
 
 impl TabOptions {
+    /// Computes a new TabOptions struct, delegating properties to Other if not set in Self
+    /// Doc is not inherited.
     pub fn or(self, other: Self) -> Self {
         let env = if let Some(mut env) = self.env {
             if let Some(other_env) = other.env {
@@ -145,7 +147,7 @@ impl TabOptions {
         };
 
         Self {
-            doc: self.doc.or(other.doc),
+            doc: self.doc,
             shell: self.shell.or(other.shell),
             env,
         }

--- a/tab-daemon/src/bus/cli.rs
+++ b/tab-daemon/src/bus/cli.rs
@@ -262,6 +262,7 @@ mod forward_tests {
         prelude::*, service::pty::scrollback::ScrollbackBuffer, state::pty::PtyScrollback,
     };
     use lifeline::{assert_completes, assert_times_out};
+    use std::collections::HashMap;
     use std::sync::Arc;
     use tab_api::{
         chunk::OutputChunk,
@@ -283,6 +284,7 @@ mod forward_tests {
             id: TabId(0),
             name: "name".into(),
             dimensions: (1, 1),
+            env: HashMap::new(),
             shell: "bash".into(),
             dir: "dir".into(),
         };
@@ -456,6 +458,7 @@ mod reverse_tests {
         prelude::*,
     };
     use lifeline::assert_completes;
+    use std::collections::HashMap;
     use tab_api::{
         chunk::InputChunk,
         tab::{CreateTabMetadata, TabId},
@@ -474,6 +477,7 @@ mod reverse_tests {
         let create = CreateTabMetadata {
             name: "name".into(),
             shell: "bash".into(),
+            env: HashMap::new(),
             dimensions: (1, 1),
             dir: "dir".into(),
         };

--- a/tab-daemon/src/service/cli.rs
+++ b/tab-daemon/src/service/cli.rs
@@ -226,6 +226,7 @@ mod request_tests {
             id: TabId(0),
             name: "name".into(),
             dimensions: (1, 2),
+            env: HashMap::new(),
             shell: "bash".into(),
             dir: "/".into(),
         };
@@ -314,11 +315,15 @@ mod request_tests {
         let mut tx = cli_bus.tx::<Request>()?;
         let mut rx = cli_bus.rx::<CliSend>()?;
 
+        let mut env = HashMap::new();
+        env.insert("foo".into(), "bar".into());
+
         let tab = CreateTabMetadata {
             name: "name".into(),
             dimensions: (1, 2),
             shell: "shell".into(),
             dir: "/".into(),
+            env,
         };
         tx.send(Request::CreateTab(tab.clone())).await?;
 
@@ -426,6 +431,7 @@ mod recv_tests {
     use super::CliService;
     use crate::{bus::CliBus, message::cli::CliRecv};
     use lifeline::{assert_completes, Bus, Receiver, Sender, Service};
+    use std::collections::HashMap;
     use tab_api::{
         client::Response,
         tab::{TabId, TabMetadata},
@@ -443,6 +449,7 @@ mod recv_tests {
             id: TabId(0),
             name: "name".into(),
             dimensions: (1, 2),
+            env: HashMap::new(),
             shell: "shell".into(),
             dir: "/".into(),
         };

--- a/tab-daemon/src/service/pty.rs
+++ b/tab-daemon/src/service/pty.rs
@@ -113,6 +113,7 @@ mod websocket_tests {
         message::pty::{PtySend, PtyShutdown},
     };
     use lifeline::{assert_completes, assert_times_out, Bus, Receiver, Sender, Service};
+    use std::collections::HashMap;
     use tab_api::{
         chunk::OutputChunk,
         pty::PtyWebsocketResponse,
@@ -131,6 +132,7 @@ mod websocket_tests {
             id: TabId(0),
             name: "name".into(),
             dimensions: (1, 2),
+            env: HashMap::new(),
             shell: "shell".into(),
             dir: "/".into(),
         };
@@ -219,6 +221,7 @@ mod daemon_tests {
     use super::PtyService;
     use crate::{bus::PtyBus, message::pty::PtyRecv};
     use lifeline::{assert_completes, Bus, Receiver, Sender, Service};
+    use std::collections::HashMap;
     use tab_api::{
         chunk::InputChunk,
         pty::PtyWebsocketRequest,
@@ -237,6 +240,7 @@ mod daemon_tests {
             id: TabId(0),
             name: "name".into(),
             dimensions: (1, 2),
+            env: HashMap::new(),
             shell: "shell".into(),
             dir: "/".into(),
         };

--- a/tab-pty/src/service/client.rs
+++ b/tab-pty/src/service/client.rs
@@ -4,7 +4,7 @@ use crate::prelude::*;
 use super::pty::PtyService;
 use lifeline::dyn_bus::DynBus;
 use std::{
-    collections::{hash_map::DefaultHasher, HashMap},
+    collections::hash_map::DefaultHasher,
     hash::{Hash, Hasher},
     path::PathBuf,
 };
@@ -59,7 +59,7 @@ impl ClientService {
                     debug!("initializing on tab {}", create.id);
                     let name = create.name.clone();
 
-                    let mut env = HashMap::new();
+                    let mut env = create.env.clone();
                     env.insert("SHELL".to_string(), create.shell.clone());
                     env.insert("TAB".to_string(), create.name.clone());
                     env.insert("TAB_ID".to_string(), create.id.0.to_string());


### PR DESCRIPTION
- Add `env`, a map property that can be set for any tab.
- Add `shell`, a string property that can be set for any tab.
- Add inheritance to repo tabs (between the root tab, and subtabs)
- Add inheritance to workspace tabs (between the root tab, and inline workspace tabs)