### PR TITLE
Only log workspace errors once

### DIFF
--- a/tab-command/src/service/workspace.rs
+++ b/tab-command/src/service/workspace.rs
@@ -27,11 +27,15 @@ impl Service for WorkspaceService {
 
         #[allow(unreachable_code)]
         let _monitor = Self::try_task("monitor", async move {
+            let mut logged = false;
             loop {
                 let state = load_state();
 
                 if let Err(err) = state {
-                    error!("failed to load config: {:?}", err);
+                    if !logged {
+                        error!("failed to load config: {:?}", err);
+                        logged = true;
+                    }
                 } else {
                     let loader_state = state.unwrap();
                     let tabs = tabs(loader_state);


### PR DESCRIPTION
Until `tab --check` is implemented, clean up the UX on a workspace parse error.

Instead of repeatedly logging errors, only log once.