### PR TITLE
Cleaner shutdown using Lifeline Barriers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -746,6 +746,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "lifeline"
+version = "0.4.0"
+source = "git+https://github.com/austinjones/lifeline-rs.git#4d699be4f5a146e544a16f6a9b633b786bb5509a"
+dependencies = [
+ "anyhow",
+ "arc-swap",
+ "async-trait",
+ "futures-util",
+ "lockfree",
+ "log",
+ "pin-project",
+ "regex",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -758,6 +775,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
 dependencies = [
  "scopeguard",
+]
+
+[[package]]
+name = "lockfree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74ee94b5ad113c7cb98c5a040f783d0952ee4fe100993881d1673c2cb002dd23"
+dependencies = [
+ "owned-alloc",
 ]
 
 [[package]]
@@ -945,6 +971,12 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "owned-alloc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30fceb411f9a12ff9222c5f824026be368ff15dc2f13468d850c7d3f502205d6"
 
 [[package]]
 name = "parking_lot"
@@ -1451,15 +1483,15 @@ dependencies = [
  "dialoguer",
  "dirs",
  "insta",
- "lifeline",
+ "lifeline 0.3.3",
  "log",
  "simplelog",
  "snailquote",
  "strip-ansi-escapes",
- "tab-api 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tab-api",
  "tab-command",
- "tab-daemon 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tab-pty 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tab-daemon",
+ "tab-pty",
  "tempfile",
  "tokio",
  "tokio-test",
@@ -1473,25 +1505,7 @@ version = "0.4.0"
 dependencies = [
  "anyhow",
  "dirs",
- "lifeline",
- "log",
- "serde",
- "serde_yaml",
- "snailquote",
- "sysinfo",
- "thiserror",
- "tokio",
-]
-
-[[package]]
-name = "tab-api"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a46e31dc8355d70fa3bb0d8aae71e1f0901ebf279d4a83c43313c9fc92114d85"
-dependencies = [
- "anyhow",
- "dirs",
- "lifeline",
+ "lifeline 0.4.0",
  "log",
  "serde",
  "serde_yaml",
@@ -1509,14 +1523,14 @@ dependencies = [
  "clap",
  "crossterm",
  "fuzzy-matcher",
- "lifeline",
+ "lifeline 0.4.0",
  "log",
  "semver",
  "serde",
  "serde_yaml",
  "simplelog",
- "tab-api 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tab-websocket 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tab-api",
+ "tab-websocket",
  "thiserror",
  "tokio",
  "tokio-test",
@@ -1532,13 +1546,13 @@ dependencies = [
  "base64 0.13.0",
  "dirs",
  "http",
- "lifeline",
+ "lifeline 0.4.0",
  "log",
  "rand",
  "serde_yaml",
  "simplelog",
- "tab-api 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tab-websocket 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tab-api",
+ "tab-websocket",
  "thiserror",
  "tokio",
  "tokio-io",
@@ -1547,28 +1561,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tab-daemon"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2bb1ce6033e76ac34d687386a4ccd4a6faec9b97ce517a14fcddaa587042ed4"
-dependencies = [
- "anyhow",
- "async-trait",
- "base64 0.13.0",
- "dirs",
- "lifeline",
- "log",
- "rand",
- "serde_yaml",
- "simplelog",
- "tab-api 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tab-websocket 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror",
- "tokio",
- "tokio-io",
-]
-
-[[package]]
 name = "tab-pty"
 version = "0.4.0"
 dependencies = [
@@ -1578,39 +1570,14 @@ dependencies = [
  "bincode",
  "dirs",
  "futures 0.3.6",
- "lifeline",
+ "lifeline 0.4.0",
  "log",
  "rand",
  "serde_yaml",
  "simplelog",
- "tab-api 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tab-pty-process 0.2.0",
- "tab-websocket 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror",
- "tokio",
- "tokio-io",
-]
-
-[[package]]
-name = "tab-pty"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbf8115a70aae4427d7c3700b13d510a8f460dd19635d5ff56723858790bb00"
-dependencies = [
- "anyhow",
- "async-trait",
- "base64 0.12.3",
- "bincode",
- "dirs",
- "futures 0.3.6",
- "lifeline",
- "log",
- "rand",
- "serde_yaml",
- "simplelog",
- "tab-api 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tab-pty-process 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tab-websocket 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tab-api",
+ "tab-pty-process",
+ "tab-websocket",
  "thiserror",
  "tokio",
  "tokio-io",
@@ -1630,20 +1597,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tab-pty-process"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4b92455283e9992144259f518c09f80f15493329d0a3dc6700d15bd3547ab2d"
-dependencies = [
- "async-trait",
- "bytes 0.4.12",
- "futures 0.3.6",
- "libc",
- "mio 0.6.22",
- "tokio",
-]
-
-[[package]]
 name = "tab-websocket"
 version = "0.3.4"
 dependencies = [
@@ -1651,30 +1604,12 @@ dependencies = [
  "async-tungstenite",
  "bincode",
  "futures 0.3.6",
- "lifeline",
+ "lifeline 0.4.0",
  "log",
  "serde",
  "thiserror",
  "tokio",
  "tokio-test",
- "tungstenite",
-]
-
-[[package]]
-name = "tab-websocket"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52cc3b88f37ffec522bdbe6ff1b2b671cdce0ef270014ea0a2fd4dbfb9f0085b"
-dependencies = [
- "anyhow",
- "async-tungstenite",
- "bincode",
- "futures 0.3.6",
- "lifeline",
- "log",
- "serde",
- "thiserror",
- "tokio",
  "tungstenite",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ members = [
 # Uncomment and commit when you make changes to a local crate
 # These will be replaced with published crates.io versions during the release process
 
-# tab-api = { path = './common/tab-api/' }
-# tab-websocket = { path = './common/tab-websocket/' }
+tab-api = { path = './common/tab-api/' }
+tab-websocket = { path = './common/tab-websocket/' }
 tab-command = { path = './tab-command/' }
-# tab-daemon = { path = './tab-daemon/' }
-# tab-pty = { path = './tab-pty/' }
+tab-daemon = { path = './tab-daemon/' }
+tab-pty = { path = './tab-pty/' }

--- a/common/tab-api/Cargo.toml
+++ b/common/tab-api/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-lifeline = "0.3"
+lifeline = { git = "https://github.com/austinjones/lifeline-rs.git" }
 tokio = { version = "0.2", features = ["macros", "process", "time"] }
 sysinfo = "0.15"
 dirs = "3.0"

--- a/common/tab-api/src/client.rs
+++ b/common/tab-api/src/client.rs
@@ -52,7 +52,7 @@ pub enum Response {
     TabUpdate(TabMetadata),
     /// A notification that the client is being re-tasks, and will now be serving the user on another tab.
     Retask(TabId),
-    /// A notification that the tab has been terminated
+    /// A notification that the active tab has been terminated
     TabTerminated(TabId),
 }
 

--- a/common/tab-websocket/Cargo.toml
+++ b/common/tab-websocket/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-lifeline = "0.3"
+lifeline = { git = "https://github.com/austinjones/lifeline-rs.git" }
 
 tungstenite = { version = "0.11", default-features = false }
 async-tungstenite = { version = "0.8", features = ["tokio-runtime"] }

--- a/tab-command/Cargo.toml
+++ b/tab-command/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 [dependencies]
 tab-api = "0.4.0"
 tab-websocket = "0.3.4"
-lifeline = "0.3"
+lifeline = { git = "https://github.com/austinjones/lifeline-rs.git" }
 
 clap = "2.33.2"
 crossterm = { version = "0.17", features = ["event-stream"] }

--- a/tab-command/src/message.rs
+++ b/tab-command/src/message.rs
@@ -1,4 +1,3 @@
-pub mod client;
 pub mod fuzzy;
 pub mod main;
 pub mod tabs;

--- a/tab-command/src/message/client.rs
+++ b/tab-command/src/message/client.rs
@@ -1,4 +1,0 @@
-use tab_api::tab::TabId;
-
-#[derive(Clone, Debug)]
-pub struct TabTerminated(pub TabId);

--- a/tab-command/src/message/tabs.rs
+++ b/tab-command/src/message/tabs.rs
@@ -14,7 +14,6 @@ pub enum TabRecv {
 pub enum TabsRecv {
     Init(HashMap<TabId, TabMetadata>),
     Update(TabMetadata),
-    Terminated(TabId),
 }
 
 #[derive(Debug, Clone)]

--- a/tab-command/src/service/tab/active_tabs.rs
+++ b/tab-command/src/service/tab/active_tabs.rs
@@ -35,9 +35,6 @@ impl Service for ActiveTabsService {
                         state.insert(metadata.id, metadata.clone());
                         tx_metadata.send(metadata.clone()).await?;
                     }
-                    TabsRecv::Terminated(id) => {
-                        state.remove(&id);
-                    }
                 }
 
                 tx.send(Some(ActiveTabsState {

--- a/tab-daemon/Cargo.toml
+++ b/tab-daemon/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 [dependencies]
 tab-api = "0.4.0"
 tab-websocket = "0.3.4"
-lifeline = "0.3"
+lifeline = { git = "https://github.com/austinjones/lifeline-rs.git" }
 
 dirs = "3.0"
 serde_yaml = "0.8"

--- a/tab-daemon/src/bus/cli.rs
+++ b/tab-daemon/src/bus/cli.rs
@@ -10,9 +10,8 @@ use crate::{
 };
 
 use anyhow::Context;
-use lifeline::{subscription, Resource};
 use std::sync::Arc;
-use tab_api::{client::Request, client::Response, tab::TabId};
+use tab_api::{client::Request, client::Response};
 use tab_websocket::{bus::WebsocketMessageBus, resource::connection::WebsocketResource};
 use time::Duration;
 use tokio::{
@@ -48,10 +47,6 @@ impl Message<CliBus> for CliSubscriptionSend {
 
 impl Message<CliBus> for CliSubscriptionRecv {
     type Channel = mpsc::Sender<Self>;
-}
-
-impl Message<CliBus> for subscription::Subscription<TabId> {
-    type Channel = subscription::Sender<TabId>;
 }
 
 /// This binding needs to be mpsc, as it is carried from the listener.

--- a/tab-daemon/src/message/cli.rs
+++ b/tab-daemon/src/message/cli.rs
@@ -65,9 +65,6 @@ pub enum CliSubscriptionRecv {
     Stopped(TabId),
 }
 
-#[derive(Clone, Debug, Default)]
-pub struct CliSubscriptionOutputBarrier {}
-
 /// A message sent by the client's subscription state service
 /// Represented with the current state of the subscription, contains tab updates and output chunks
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/tab-daemon/src/message/cli.rs
+++ b/tab-daemon/src/message/cli.rs
@@ -46,8 +46,6 @@ pub enum CliSend {
 pub enum CliRecv {
     /// A notification that a tab with the given metadata has started, and is ready for subscriptions.
     TabStarted(TabMetadata),
-    /// A notification that a tab has been terminated.
-    TabStopped(TabId),
 }
 
 /// A message sent to the command client's tab subscription service
@@ -63,7 +61,12 @@ pub enum CliSubscriptionRecv {
     Output(TabOutput),
     /// A notification that a tab has been retasked.  The client may need to request scrollback and change their subscriptions.
     Retask(TabId, TabId),
+    /// Notification that a tab has stopped
+    Stopped(TabId),
 }
+
+#[derive(Clone, Debug, Default)]
+pub struct CliSubscriptionOutputBarrier {}
 
 /// A message sent by the client's subscription state service
 /// Represented with the current state of the subscription, contains tab updates and output chunks
@@ -71,6 +74,7 @@ pub enum CliSubscriptionRecv {
 pub enum CliSubscriptionSend {
     Retask(TabId),
     Output(TabId, OutputChunk),
+    Stopped(TabId),
 }
 
 /// Terminates the websocket connection & supporing services.

--- a/tab-daemon/src/service/cli.rs
+++ b/tab-daemon/src/service/cli.rs
@@ -235,7 +235,6 @@ mod request_tests {
 
         let _service = CliService::spawn(&cli_bus)?;
         let mut rx = cli_bus.rx::<Response>()?;
-        rx.log();
 
         assert_completes!(async move {
             let init = rx.recv().await;

--- a/tab-daemon/src/service/cli.rs
+++ b/tab-daemon/src/service/cli.rs
@@ -235,6 +235,7 @@ mod request_tests {
 
         let _service = CliService::spawn(&cli_bus)?;
         let mut rx = cli_bus.rx::<Response>()?;
+        rx.log();
 
         assert_completes!(async move {
             let init = rx.recv().await;

--- a/tab-daemon/src/service/cli/subscription.rs
+++ b/tab-daemon/src/service/cli/subscription.rs
@@ -16,7 +16,7 @@ impl Service for CliSubscriptionService {
 
     fn spawn(bus: &Self::Bus) -> Self::Lifeline {
         let _rx = {
-            let mut rx = bus.rx::<CliSubscriptionRecv>()?.log();
+            let mut rx = bus.rx::<CliSubscriptionRecv>()?;
             let mut tx = bus.tx::<CliSubscriptionSend>()?;
             let mut tx_daemon = bus.tx::<CliSend>()?;
 

--- a/tab-daemon/src/service/cli/subscription.rs
+++ b/tab-daemon/src/service/cli/subscription.rs
@@ -81,6 +81,13 @@ impl Service for CliSubscriptionService {
                                 }
                             }
                         }
+                        CliSubscriptionRecv::Stopped(id) => {
+                            if !state.is_selected(id) {
+                                continue;
+                            }
+
+                            tx.send(CliSubscriptionSend::Stopped(id)).await?;
+                        }
                     }
                 }
                 Ok(())

--- a/tab-daemon/src/service/daemon/listener.rs
+++ b/tab-daemon/src/service/daemon/listener.rs
@@ -10,7 +10,6 @@ use crate::{
     service::{cli::CliService, pty::PtyService},
 };
 use crate::{prelude::*, service::cli::subscription::CliSubscriptionService};
-use anyhow::Context;
 
 use lifeline::dyn_bus::DynBus;
 use tab_websocket::{
@@ -155,10 +154,7 @@ impl ListenerService {
         let _subscription = CliSubscriptionService::spawn(&bus)?;
         drop(bus);
 
-        shutdown
-            .recv()
-            .await
-            .context("rx ConnectionShutdown closed")?;
+        shutdown.recv().await;
 
         Ok(())
     }
@@ -170,10 +166,7 @@ impl ListenerService {
         let _service = PtyService::spawn(&bus)?;
         drop(bus);
 
-        shutdown
-            .recv()
-            .await
-            .context("rx ConnectionShutdown closed")?;
+        shutdown.recv().await;
 
         Ok(())
     }

--- a/tab-daemon/src/service/daemon/tab_manager.rs
+++ b/tab-daemon/src/service/daemon/tab_manager.rs
@@ -101,6 +101,7 @@ impl TabManagerService {
         tx_close: &mut impl Sender<TabRecv>,
         tx_tabs_state: &mut impl Sender<TabsState>,
     ) -> anyhow::Result<()> {
+        info!("TabManager terminating tab {}", id);
         tabs.remove(&id);
 
         tx.send(TabManagerSend::TabTerminated(id))

--- a/tab-daemon/src/service/pty.rs
+++ b/tab-daemon/src/service/pty.rs
@@ -43,7 +43,7 @@ impl Service for PtyService {
                             tx_daemon.send(PtySend::Output(output)).await?;
                         }
                         PtyWebsocketResponse::Stopped => {
-                            debug!("received pty shutdown notification");
+                            info!("PTY process has terminated");
                             tx_daemon.send(PtySend::Stopped).await?;
 
                             // this sleep is not visible to the user

--- a/tab-pty/Cargo.toml
+++ b/tab-pty/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 [dependencies]
 tab-api = "0.4.0"
 tab-websocket = "0.3.4"
-lifeline = "0.3"
+lifeline = { git = "https://github.com/austinjones/lifeline-rs.git" }
 
 dirs = "3.0"
 serde_yaml = "0.8"

--- a/tab-pty/src/lib.rs
+++ b/tab-pty/src/lib.rs
@@ -51,6 +51,7 @@ async fn main_async() -> anyhow::Result<()> {
 
     let (_tx, rx, _lifeline) = spawn().await?;
     wait_for_shutdown(rx).await;
+    info!("PTY process terminated.");
 
     Ok(())
 }

--- a/tab-pty/src/message/pty.rs
+++ b/tab-pty/src/message/pty.rs
@@ -53,3 +53,6 @@ pub struct PtyOptions {
 }
 
 impl_storage_clone!(PtyOptions);
+
+#[derive(Clone, Debug, Default)]
+pub struct PtyOutputBarrier {}

--- a/tab-pty/src/service/client.rs
+++ b/tab-pty/src/service/client.rs
@@ -236,6 +236,7 @@ impl ClientSessionService {
 
                     tx.send(PtyWebsocketResponse::Stopped).await?;
 
+                    // this sleep is not visible to the user
                     time::delay_for(Duration::from_millis(500)).await;
                     tx_shutdown.send(PtyShutdown {}).await?;
                 }

--- a/tab-pty/src/service/client.rs
+++ b/tab-pty/src/service/client.rs
@@ -138,7 +138,7 @@ impl ClientService {
                 PtyWebsocketRequest::Terminate => {
                     // in case we somehow get a pty termination request, but don't have a session running,
                     // send a main shutdown message
-                    time::delay_for(Duration::from_millis(100)).await;
+                    time::delay_for(Duration::from_millis(2000)).await;
                     tx_shutdown.send(MainShutdown {}).await?;
                 }
             }
@@ -176,8 +176,12 @@ impl Service for ClientSessionService {
         let _input = {
             let rx_request = bus.rx::<PtyWebsocketRequest>()?;
             let tx_pty = bus.tx::<PtyRequest>()?;
+            let tx_websocket = bus.tx::<PtyWebsocketResponse>()?;
             let tx_shutdown = bus.tx::<PtyShutdown>()?;
-            Self::try_task("input", Self::input(rx_request, tx_pty, tx_shutdown))
+            Self::try_task(
+                "input",
+                Self::input(rx_request, tx_pty, tx_websocket, tx_shutdown),
+            )
         };
 
         Ok(Self {
@@ -192,6 +196,7 @@ impl ClientSessionService {
     async fn input(
         mut rx: impl Receiver<PtyWebsocketRequest>,
         mut tx_pty: impl Sender<PtyRequest>,
+        mut tx_websocket: impl Sender<PtyWebsocketResponse>,
         mut tx_shutdown: impl Sender<PtyShutdown>,
     ) -> anyhow::Result<()> {
         while let Some(request) = rx.recv().await {
@@ -206,7 +211,12 @@ impl ClientSessionService {
 
                     tx_pty.send(PtyRequest::Shutdown).await.ok();
 
-                    time::delay_for(Duration::from_millis(20)).await;
+                    // The shell should shut down, and emit a shutdown message.
+                    // If it doesn't within a reasonable time,
+                    //   we'll forcefully kill it.
+                    time::delay_for(Duration::from_millis(1000)).await;
+                    warn!("Shell process did not shut down within the 1 second timeout.");
+                    tx_websocket.send(PtyWebsocketResponse::Stopped).await?;
                     tx_shutdown.send(PtyShutdown {}).await?;
                 }
                 PtyWebsocketRequest::Resize(dimensions) => {
@@ -237,7 +247,7 @@ impl ClientSessionService {
                     tx.send(PtyWebsocketResponse::Stopped).await?;
 
                     // this sleep is not visible to the user
-                    time::delay_for(Duration::from_millis(500)).await;
+                    time::delay_for(Duration::from_millis(100)).await;
                     tx_shutdown.send(PtyShutdown {}).await?;
                 }
             }

--- a/tab-pty/src/service/pty.rs
+++ b/tab-pty/src/service/pty.rs
@@ -70,6 +70,8 @@ impl PtyService {
         let _exit_code = Self::try_task("exit_code", async move {
             let exit_code = child.await?;
             rx_barrier.await;
+
+            info!("Shell successfully terminated with exit code {}", exit_code);
             tx_exit.send(PtyResponse::Terminated(exit_code)).await?;
 
             Ok(())

--- a/tab-pty/src/service/pty.rs
+++ b/tab-pty/src/service/pty.rs
@@ -1,7 +1,7 @@
-use crate::message::pty::{PtyOptions, PtyRequest, PtyResponse, PtyShutdown};
+use crate::message::pty::{PtyOptions, PtyOutputBarrier, PtyRequest, PtyResponse, PtyShutdown};
 use crate::prelude::*;
 
-use lifeline::{Receiver, Sender};
+use lifeline::{barrier::*, Receiver, Sender};
 use std::process::{Command, Stdio};
 use tab_api::{
     chunk::{InputChunk, OutputChunk},
@@ -11,11 +11,7 @@ use tab_pty_process::CommandExt;
 use tab_pty_process::{
     AsyncPtyMaster, AsyncPtyMasterReadHalf, AsyncPtyMasterWriteHalf, Child, PtyMaster,
 };
-use time::Duration;
-use tokio::{
-    io::{AsyncReadExt, AsyncWriteExt},
-    time,
-};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 static CHUNK_LEN: usize = 2048;
 static OUTPUT_CHANNEL_SIZE: usize = 32;
@@ -61,16 +57,19 @@ impl PtyService {
         tx_response: impl Sender<PtyResponse> + Clone + Send + 'static,
     ) -> anyhow::Result<()> {
         let (child, read, write) = Self::create_pty(options).await?;
+        let (tx_barrier, rx_barrier) = barrier();
         // stdout reader
-        let _output = Self::task("output", Self::read_output(read, tx_response.clone()));
+        let _output = Self::task(
+            "output",
+            Self::read_output(read, tx_response.clone(), tx_barrier),
+        );
         let _input = Self::task("input", Self::write_input(write, rx_request));
 
         let mut tx_exit = tx_response.clone();
 
         let _exit_code = Self::try_task("exit_code", async move {
             let exit_code = child.await?;
-            // await long enough for the final stdout read to get through
-            time::delay_for(Duration::from_millis(10)).await;
+            rx_barrier.await;
             tx_exit.send(PtyResponse::Terminated(exit_code)).await?;
 
             Ok(())
@@ -108,12 +107,16 @@ impl PtyService {
         Ok((child, read, write))
     }
 
-    async fn read_output(mut channel: impl AsyncReadExt + Unpin, mut tx: impl Sender<PtyResponse>) {
+    async fn read_output(
+        mut channel: impl AsyncReadExt + Unpin,
+        mut tx: impl Sender<PtyResponse>,
+        _barrier: Barrier<PtyOutputBarrier>,
+    ) {
         let mut index = 0usize;
         let mut buffer = vec![0u8; CHUNK_LEN];
         while let Ok(read) = channel.read(buffer.as_mut_slice()).await {
             if read == 0 {
-                continue;
+                break;
             }
 
             trace!("Read {} bytes", read);
@@ -126,10 +129,6 @@ impl PtyService {
 
             tx.send(response).await.ok();
             index += read;
-
-            // a very short delay allows things to batch up
-            // without any buffering, the message rate can get very high
-            time::delay_for(Duration::from_millis(5)).await;
         }
     }
 

--- a/tab/Cargo.toml
+++ b/tab/Cargo.toml
@@ -10,6 +10,9 @@ homepage = "https://github.com/austinjones/tab-rs"
 repository = "https://github.com/austinjones/tab-rs"
 license = "MIT"
 readme = "../README.md"
+exclude = [
+    "tests/snapshots/*"
+]
 
 [[bin]]
 name = "tab"

--- a/tab/tests/common/mod.rs
+++ b/tab/tests/common/mod.rs
@@ -113,8 +113,7 @@ impl<'s> TestCommand<'s> {
         info!("Tab command initalizing: {}", self.tab.as_str());
 
         let mut run = tokio::process::Command::new(self.session.binary());
-        run
-            .arg("--log")
+        run.arg("--log")
             .arg("info")
             .arg(self.tab.as_str())
             .env("SHELL", "/bin/bash")
@@ -204,11 +203,15 @@ impl<'s> TestCommand<'s> {
                                     search_index += index + match_target.len();
                                     break;
                                 }
-                                
+
                                 if Instant::now().duration_since(start_time) > *timeout {
                                     error!("Await timeout for stdout: {}", string);
-                                    error!("Current buffer: {}", 
-                                        snailquote::escape(std::str::from_utf8(stdout_buffer.as_slice()).unwrap()));
+                                    error!(
+                                        "Current buffer: {}",
+                                        snailquote::escape(
+                                            std::str::from_utf8(stdout_buffer.as_slice()).unwrap()
+                                        )
+                                    );
                                     break;
                                 }
 

--- a/tab/tests/common/mod.rs
+++ b/tab/tests/common/mod.rs
@@ -207,10 +207,6 @@ impl<'s> TestCommand<'s> {
         let stdout_buffer =
             strip_ansi_escapes::strip(&stdout_buffer).expect("couldn't strip escape sequences");
         let stdout = std::str::from_utf8(stdout_buffer.as_slice())?.to_string();
-        // the PTY sometimes cannot forward the final exit message before it quits
-        // adding sleeps was not an option, as users are waiting for the exit to occur so they can context switch
-        // we strip this message here, so it doesn't appear in the snapshot
-        let stdout = stdout.replace("\nexit\n", "\n");
 
         let result = TestResult {
             exit_status: code?,

--- a/tab/tests/common/mod.rs
+++ b/tab/tests/common/mod.rs
@@ -113,7 +113,10 @@ impl<'s> TestCommand<'s> {
         info!("Tab command initalizing: {}", self.tab.as_str());
 
         let mut run = tokio::process::Command::new(self.session.binary());
-        run.arg(self.tab.as_str())
+        run
+            .arg("--log")
+            .arg("debug")
+            .arg(self.tab.as_str())
             .env("SHELL", "/bin/bash")
             .env(
                 "TAB_RUNTIME_DIR",

--- a/tab/tests/reconnect.rs
+++ b/tab/tests/reconnect.rs
@@ -2,7 +2,6 @@ use insta::assert_snapshot;
 
 mod common;
 use common::*;
-use log::info;
 
 /// Tests that a session can be established, disconnected from, and re-established
 /// Covers connection, ctrl-W, disconnection, and scrollback
@@ -10,7 +9,7 @@ use log::info;
 async fn reconnect() -> anyhow::Result<()> {
     let mut session = TestSession::new()?;
 
-    for i in 0..1 {
+    for i in 0..10 {
         reconnect_iter(&mut session, i).await?;
     }
 
@@ -22,10 +21,10 @@ async fn reconnect_iter(session: &mut TestSession, iter: usize) -> anyhow::Resul
     let result = session
         .command()
         .tab(tab.as_str())
-        .await_stdout("$", 5000)
-        .stdin("echo foo\n")
-        .await_stdout("echo foo", 1000)
         .await_stdout("$", 1000)
+        .stdin("echo foo\n")
+        .await_stdout("echo foo", 300)
+        .await_stdout("$", 300)
         .stdin_bytes(&[23u8])
         .run()
         .await?;
@@ -36,15 +35,14 @@ async fn reconnect_iter(session: &mut TestSession, iter: usize) -> anyhow::Resul
     let result = session
         .command()
         .tab(tab.as_str())
-        .await_stdout("foo", 5000)
+        .await_stdout("foo", 1000)
         .stdin("exit\n")
-        .await_stdout("exit", 200)
+        .await_stdout("exit", 300)
         .complete_snapshot()
         .run()
         .await?;
     assert_eq!(Some(0), result.exit_status.code());
     assert_snapshot!("after", &result.snapshot);
-    info!("after: {}", result.snapshot);
 
     Ok(())
 }

--- a/tab/tests/reconnect.rs
+++ b/tab/tests/reconnect.rs
@@ -38,6 +38,7 @@ async fn reconnect_iter(session: &mut TestSession, iter: usize) -> anyhow::Resul
         .await_stdout("foo", 5000)
         .stdin("exit\n")
         .await_stdout("exit", 200)
+        .await_stdout("exit", 200)
         .run()
         .await?;
     assert_eq!(Some(0), result.exit_status.code());

--- a/tab/tests/session.rs
+++ b/tab/tests/session.rs
@@ -28,6 +28,7 @@ async fn session_iter(session: &mut TestSession, iter: usize) -> anyhow::Result<
         .await_stdout("$", 200)
         .stdin("exit\n")
         .await_stdout("exit", 200)
+        .await_stdout("exit", 200)
         .run()
         .await?;
 

--- a/tab/tests/session.rs
+++ b/tab/tests/session.rs
@@ -22,12 +22,12 @@ async fn session_iter(session: &mut TestSession, iter: usize) -> anyhow::Result<
     let result = session
         .command()
         .tab(tab)
-        .await_stdout("$", 5000)
+        .await_stdout("$", 1000)
         .stdin("echo foo\n")
-        .await_stdout("echo foo", 1000)
-        .await_stdout("$", 200)
+        .await_stdout("echo foo", 300)
+        .await_stdout("$", 300)
         .stdin("exit\n")
-        .await_stdout("exit", 1000)
+        .await_stdout("exit", 300)
         .complete_snapshot()
         .run()
         .await?;

--- a/tab/tests/session.rs
+++ b/tab/tests/session.rs
@@ -28,7 +28,7 @@ async fn session_iter(session: &mut TestSession, iter: usize) -> anyhow::Result<
         .await_stdout("$", 200)
         .stdin("exit\n")
         .await_stdout("exit", 200)
-        .await_stdout("exit", 200)
+        .complete_snapshot()
         .run()
         .await?;
 

--- a/tab/tests/session.rs
+++ b/tab/tests/session.rs
@@ -27,13 +27,13 @@ async fn session_iter(session: &mut TestSession, iter: usize) -> anyhow::Result<
         .await_stdout("echo foo", 1000)
         .await_stdout("$", 200)
         .stdin("exit\n")
-        .await_stdout("exit", 200)
+        .await_stdout("exit", 1000)
         .complete_snapshot()
         .run()
         .await?;
 
     assert_eq!(Some(0), result.exit_status.code());
-    assert_snapshot!("result", result.stdout);
+    assert_snapshot!("result", result.snapshot);
 
     Ok(())
 }

--- a/tab/tests/simple.rs
+++ b/tab/tests/simple.rs
@@ -10,38 +10,16 @@ use log::info;
 async fn reconnect() -> anyhow::Result<()> {
     let mut session = TestSession::new()?;
 
-    for i in 0..1 {
-        reconnect_iter(&mut session, i).await?;
-    }
-
-    Ok(())
-}
-
-async fn reconnect_iter(session: &mut TestSession, iter: usize) -> anyhow::Result<()> {
-    let tab = format!("reconnect/{}/", iter);
     let result = session
         .command()
-        .tab(tab.as_str())
+        .tab("simple/")
         .await_stdout("$", 5000)
-        .stdin("echo foo\n")
-        .await_stdout("echo foo", 1000)
-        .await_stdout("$", 1000)
-        .stdin_bytes(&[23u8])
-        .run()
-        .await?;
-
-    assert_eq!(Some(0), result.exit_status.code());
-    assert_snapshot!("before", result.snapshot);
-
-    let result = session
-        .command()
-        .tab(tab.as_str())
-        .await_stdout("foo", 5000)
         .stdin("exit\n")
         .await_stdout("exit", 200)
         .complete_snapshot()
         .run()
         .await?;
+
     assert_eq!(Some(0), result.exit_status.code());
     assert_snapshot!("after", &result.snapshot);
     info!("after: {}", result.snapshot);

--- a/tab/tests/simple.rs
+++ b/tab/tests/simple.rs
@@ -2,7 +2,6 @@ use insta::assert_snapshot;
 
 mod common;
 use common::*;
-use log::info;
 
 /// Tests that a session can be established, disconnected from, and re-established
 /// Covers connection, ctrl-W, disconnection, and scrollback
@@ -13,16 +12,15 @@ async fn reconnect() -> anyhow::Result<()> {
     let result = session
         .command()
         .tab("simple/")
-        .await_stdout("$", 5000)
+        .await_stdout("$", 1000)
         .stdin("exit\n")
-        .await_stdout("exit", 200)
+        .await_stdout("exit", 300)
         .complete_snapshot()
         .run()
         .await?;
 
     assert_eq!(Some(0), result.exit_status.code());
     assert_snapshot!("after", &result.snapshot);
-    info!("after: {}", result.snapshot);
 
     Ok(())
 }

--- a/tab/tests/snapshots/reconnect__after.snap
+++ b/tab/tests/snapshots/reconnect__after.snap
@@ -1,8 +1,9 @@
 ---
-source: tab-cli/tests/reconnect.rs
-expression: output
+source: tab/tests/reconnect.rs
+expression: result.stdout
 ---
 $ echo foo
 foo
 $ exit
+exit
 

--- a/tab/tests/snapshots/session__result.snap
+++ b/tab/tests/snapshots/session__result.snap
@@ -1,8 +1,9 @@
 ---
-source: tab-cli/tests/session.rs
-expression: output
+source: tab/tests/session.rs
+expression: result.stdout
 ---
 $ echo foo
 foo
 $ exit
+exit
 

--- a/tab/tests/snapshots/session__result.snap
+++ b/tab/tests/snapshots/session__result.snap
@@ -5,5 +5,4 @@ expression: result.stdout
 $ echo foo
 foo
 $ exit
-exit
 

--- a/tab/tests/snapshots/simple__after.snap
+++ b/tab/tests/snapshots/simple__after.snap
@@ -1,7 +1,6 @@
 ---
-source: tab/tests/reconnect.rs
+source: tab/tests/simple.rs
 expression: "&result.snapshot"
 ---
-$ echo foo
-foo
 $ exit
+

--- a/tab/tests/switch.rs
+++ b/tab/tests/switch.rs
@@ -37,10 +37,10 @@ async fn session_iter(session: &mut TestSession, iter: usize) -> anyhow::Result<
     let result = session
         .command()
         .tab(tab_from.as_str())
-        .await_stdout("$", 1000)
+        .await_stdout("$", 2000)
         .stdin("echo from\n")
         .await_stdout("echo from", 200)
-        .await_stdout("$", 200)
+        .await_stdout("$", 600)
         .stdin_bytes(&[23u8])
         .run()
         .await?;
@@ -51,11 +51,12 @@ async fn session_iter(session: &mut TestSession, iter: usize) -> anyhow::Result<
     let result = session
         .command()
         .tab(tab_from)
-        .await_stdout("$", 5000)
+        .await_stdout("$", 2000)
         .stdin("$TAB_BIN target/\n")
         .await_stdout("echo target", 1000)
         .await_stdout("target", 200)
-        .await_stdout("$", 200)
+        .await_stdout("$", 1200)
+        .complete_snapshot()
         .stdin_bytes(&[23u8])
         .run()
         .await?;

--- a/tab/tests/switch.rs
+++ b/tab/tests/switch.rs
@@ -46,7 +46,7 @@ async fn session_iter(session: &mut TestSession, iter: usize) -> anyhow::Result<
         .await?;
 
     assert_eq!(Some(0), result.exit_status.code());
-    assert_snapshot!("create_from", result.stdout);
+    assert_snapshot!("create_from", result.snapshot);
 
     let result = session
         .command()
@@ -61,7 +61,7 @@ async fn session_iter(session: &mut TestSession, iter: usize) -> anyhow::Result<
         .await?;
 
     assert_eq!(Some(0), result.exit_status.code());
-    assert_snapshot!("into_target", result.stdout);
+    assert_snapshot!("into_target", result.snapshot);
 
     Ok(())
 }

--- a/tab/tests/switch.rs
+++ b/tab/tests/switch.rs
@@ -13,10 +13,10 @@ async fn session() -> anyhow::Result<()> {
     let result = session
         .command()
         .tab("target/")
-        .await_stdout("$", 5000)
+        .await_stdout("$", 1000)
         .stdin("echo target\n")
-        .await_stdout("echo target", 200)
-        .await_stdout("$", 200)
+        .await_stdout("echo target", 300)
+        .await_stdout("$", 300)
         .stdin_bytes(&[23u8])
         .run()
         .await?;
@@ -37,10 +37,10 @@ async fn session_iter(session: &mut TestSession, iter: usize) -> anyhow::Result<
     let result = session
         .command()
         .tab(tab_from.as_str())
-        .await_stdout("$", 2000)
+        .await_stdout("$", 1000)
         .stdin("echo from\n")
-        .await_stdout("echo from", 200)
-        .await_stdout("$", 600)
+        .await_stdout("echo from", 300)
+        .await_stdout("$", 300)
         .stdin_bytes(&[23u8])
         .run()
         .await?;
@@ -51,11 +51,11 @@ async fn session_iter(session: &mut TestSession, iter: usize) -> anyhow::Result<
     let result = session
         .command()
         .tab(tab_from)
-        .await_stdout("$", 2000)
+        .await_stdout("$", 1000)
         .stdin("$TAB_BIN target/\n")
         .await_stdout("echo target", 1000)
-        .await_stdout("target", 200)
-        .await_stdout("$", 1200)
+        .await_stdout("target", 300)
+        .await_stdout("$", 300)
         .complete_snapshot()
         .stdin_bytes(&[23u8])
         .run()


### PR DESCRIPTION
Remove 'short-circuiting' tab shutdown messages, and wait for the final output message before terminating the PTY process, Daemon services, and the tab command client.

- Refactor shutdown in the PTY.  Use Lifeline Barriers in the PTY to synchronize shutdown
- Refactor tab-command & tab-daemon shutdown.  Response::TabTerminated is only fired for the currently selected tab.
- Resolve a concurrency bug with the tab-cli subscription service.  The final CliSubscriptionRecv::Output message was racing CliRecv::Terminated.  Now all messages flow through CliSubscriptionRecv
- Remove many shutdown-related sleep statements, and refine the remaining statements to make more sense.  The only user-facing sleep is now the 25ms sleep in the tab command client.  All other shutdown messages are immediately propagated.
- Add a bunch of shutdown-related log statements.

Fix several tab/test bugs
- Awaiting stdout that already arrived simply fails, printing 'read timeout' several times.
- The exit behavior of /bin/bash on OSX vs Linux is different.  OSX prints 'exit'.  Remove the 'find/replace' hack, and add a function which will end the snapshot at the latest stdout match.
- Add a lot of useful test rig logging.