### PR TITLE
Remember tab docstrings

### DIFF
--- a/common/tab-api/src/tab.rs
+++ b/common/tab-api/src/tab.rs
@@ -33,6 +33,7 @@ impl Display for TabId {
 pub struct TabMetadata {
     pub id: TabId,
     pub name: String,
+    pub doc: Option<String>,
     pub dimensions: (u16, u16),
     pub env: HashMap<String, String>,
     pub shell: String,
@@ -44,6 +45,7 @@ impl TabMetadata {
         Self {
             id,
             name: create.name,
+            doc: create.doc,
             dimensions: create.dimensions,
             env: create.env,
             shell: create.shell,
@@ -57,6 +59,7 @@ impl TabMetadata {
 pub struct CreateTabMetadata {
     pub name: String,
     pub dimensions: (u16, u16),
+    pub doc: Option<String>,
     pub env: HashMap<String, String>,
     pub shell: String,
     pub dir: String,

--- a/tab-command/src/service/tab/create_tab.rs
+++ b/tab-command/src/service/tab/create_tab.rs
@@ -80,6 +80,7 @@ impl CreateTabService {
 
         let metadata = CreateTabMetadata {
             name: Self::compute_name(&workspace_tab, name.as_str()),
+            doc: workspace_tab.map(|tab| tab.doc.clone()).flatten(),
             dir: directory.to_string_lossy().to_string(),
             env,
             dimensions,

--- a/tab-command/src/state/workspace.rs
+++ b/tab-command/src/state/workspace.rs
@@ -23,9 +23,9 @@ impl WorkspaceState {
 
             let tab = WorkspaceTab {
                 name: metadata.name.clone(),
+                doc: metadata.doc.clone(),
                 directory: PathBuf::from(&metadata.dir),
                 shell: None,
-                doc: None,
                 env: None,
             };
 

--- a/tab-daemon/src/bus/cli.rs
+++ b/tab-daemon/src/bus/cli.rs
@@ -255,6 +255,7 @@ mod forward_tests {
         let started = TabMetadata {
             id: TabId(0),
             name: "name".into(),
+            doc: Some("doc".into()),
             dimensions: (1, 1),
             env: HashMap::new(),
             shell: "bash".into(),
@@ -448,6 +449,7 @@ mod reverse_tests {
 
         let create = CreateTabMetadata {
             name: "name".into(),
+            doc: Some("doc".into()),
             shell: "bash".into(),
             env: HashMap::new(),
             dimensions: (1, 1),

--- a/tab-daemon/src/service/cli.rs
+++ b/tab-daemon/src/service/cli.rs
@@ -221,6 +221,7 @@ mod request_tests {
         let tab_metadata = TabMetadata {
             id: TabId(0),
             name: "name".into(),
+            doc: Some("doc".into()),
             dimensions: (1, 2),
             env: HashMap::new(),
             shell: "bash".into(),
@@ -316,6 +317,7 @@ mod request_tests {
 
         let tab = CreateTabMetadata {
             name: "name".into(),
+            doc: Some("doc".into()),
             dimensions: (1, 2),
             shell: "shell".into(),
             dir: "/".into(),
@@ -444,6 +446,7 @@ mod recv_tests {
         let metadata = TabMetadata {
             id: TabId(0),
             name: "name".into(),
+            doc: Some("doc".into()),
             dimensions: (1, 2),
             env: HashMap::new(),
             shell: "shell".into(),

--- a/tab-daemon/src/service/pty.rs
+++ b/tab-daemon/src/service/pty.rs
@@ -127,6 +127,7 @@ mod websocket_tests {
         let tab = TabMetadata {
             id: TabId(0),
             name: "name".into(),
+            doc: Some("doc".into()),
             dimensions: (1, 2),
             env: HashMap::new(),
             shell: "shell".into(),
@@ -235,6 +236,7 @@ mod daemon_tests {
         let tab = TabMetadata {
             id: TabId(0),
             name: "name".into(),
+            doc: Some("doc".into()),
             dimensions: (1, 2),
             env: HashMap::new(),
             shell: "shell".into(),

--- a/tab-pty/src/service/client.rs
+++ b/tab-pty/src/service/client.rs
@@ -347,11 +347,12 @@ mod tests {
         let current_dir = std::env::current_dir().unwrap();
         tx.send(PtyWebsocketRequest::Init(TabMetadata {
             id: TabId(0),
-            name: "name".to_string(),
+            name: "name".into(),
+            doc: Some("doc".into()),
             dimensions: (80, 24),
             env: HashMap::new(),
-            shell: "/usr/bin/env sh".to_string(),
-            dir: current_dir.to_string_lossy().to_string(),
+            shell: "/usr/bin/env sh".into(),
+            dir: current_dir.to_string_lossy().into(),
         }))
         .await?;
 
@@ -360,11 +361,12 @@ mod tests {
             assert_eq!(
                 Some(PtyWebsocketResponse::Started(TabMetadata {
                     id: TabId(0),
-                    name: "name".to_string(),
+                    name: "name".into(),
+                    doc: Some("doc".into()),
                     dimensions: (80, 24),
                     env: HashMap::new(),
-                    shell: "/usr/bin/env sh".to_string(),
-                    dir: current_dir.to_string_lossy().to_string(),
+                    shell: "/usr/bin/env sh".into(),
+                    dir: current_dir.to_string_lossy().into(),
                 })),
                 created
             );


### PR DESCRIPTION
Remember tab docstrings for workspace tabs after navigating away from the workspace.

Resolves #190 