### PR TITLE
Clean up the workspace loader implementation

### DIFF
--- a/tab-command/src/service/tab/workspace.rs
+++ b/tab-command/src/service/tab/workspace.rs
@@ -1,17 +1,11 @@
-use crate::{
-    prelude::*,
-    state::workspace::{Config, Repo, Workspace, WorkspaceItem, WorkspaceState, WorkspaceTab},
-};
-use anyhow::Context;
+use crate::{prelude::*, state::workspace::WorkspaceState};
 use lifeline::Service;
-use std::{
-    fs::File,
-    io::BufReader,
-    path::{Path, PathBuf},
-};
-use tab_api::tab::normalize_name;
-use time::Duration;
-use tokio::time;
+
+use self::loader::scan_config;
+
+mod loader;
+mod repo;
+mod workspace;
 
 /// Loads the workspace configuration using the current directory
 pub struct WorkspaceService {
@@ -27,24 +21,11 @@ impl Service for WorkspaceService {
 
         #[allow(unreachable_code)]
         let _monitor = Self::try_task("monitor", async move {
-            let mut logged = false;
-            loop {
-                let state = load_state();
-
-                if let Err(err) = state {
-                    if !logged {
-                        error!("failed to load config: {:?}", err);
-                        logged = true;
-                    }
-                } else {
-                    let loader_state = state.unwrap();
-                    let tabs = tabs(loader_state);
-                    let state = WorkspaceState { tabs };
-                    tx.send(Some(state)).await.ok();
-                }
-
-                time::delay_for(Duration::from_millis(1000)).await;
-            }
+            let dir = std::env::current_dir()?;
+            let state = scan_config(dir.as_path(), None);
+            let tabs = state.unwrap_log();
+            let state = WorkspaceState { tabs };
+            tx.send(Some(state)).await.ok();
 
             Ok(())
         });
@@ -53,208 +34,14 @@ impl Service for WorkspaceService {
     }
 }
 
-struct LoaderState {
-    pub repos: Vec<(PathBuf, Repo)>,
-
-    /// The list of compiled tabs
-    pub tabs: Vec<WorkspaceTab>,
-
-    /// The hierarchy of workspaces, starting with the innermost
-    pub workspaces: Vec<Workspace>,
-}
-
-fn load_state() -> anyhow::Result<LoaderState> {
-    let init_dir = std::env::current_dir()?;
-    load_state_in(init_dir.as_path(), None)
-}
-
-fn load_state_in(path: &Path, base: Option<&Path>) -> anyhow::Result<LoaderState> {
-    let mut loader_state = LoaderState {
-        repos: Vec::new(),
-        tabs: Vec::new(),
-        workspaces: Vec::new(),
-    };
-
-    let mut working_dir: Option<&Path> = Some(path);
-
-    while let Some(dir) = working_dir {
-        if let Some(base) = base {
-            if dir != base && base.starts_with(dir) {
-                break;
-            }
-        }
-
-        let config = load_yml(dir);
-        if let Some(config) = config {
-            let config = config.context(dir.to_string_lossy().to_string())?;
-            match config {
-                Config::Workspace(workspace) => {
-                    load_items(dir, &workspace, &mut loader_state)?;
-                    loader_state.workspaces.push(workspace);
-                }
-                Config::Repo(repo) => {
-                    let repo_path = dir.to_path_buf();
-                    loader_state.repos.push((repo_path, repo));
-                }
-            }
-        }
-
-        working_dir = dir.parent();
-    }
-
-    Ok(loader_state)
-}
-
-fn load_yml(dir: &Path) -> Option<anyhow::Result<Config>> {
-    let mut path_buf = dir.to_owned();
-    path_buf.push("tab.yml");
-
-    if path_buf.is_file() {
-        return Some(load_file(path_buf.as_path()));
-    }
-
-    let mut path_buf = dir.to_owned();
-    path_buf.push(".tab.yml");
-
-    if path_buf.is_file() {
-        return Some(load_file(path_buf.as_path()));
-    }
-
-    None
-}
-
-fn load_file(path: &Path) -> anyhow::Result<Config> {
-    // TODO: figure out how to get rid fo the blocking IO
-    let reader = File::open(path)?;
-    let buf_reader = BufReader::new(reader);
-    let config = serde_yaml::from_reader(buf_reader)?;
-    Ok(config)
-}
-
-fn load_items(path: &Path, workspace: &Workspace, target: &mut LoaderState) -> anyhow::Result<()> {
-    if let Some(tab) = workspace_tab(path, workspace) {
-        target.tabs.push(tab);
-    }
-
-    for item in workspace.workspace.iter() {
-        match item {
-            WorkspaceItem::Workspace(link) => {
-                let mut workspace_path = path.to_path_buf();
-                workspace_path.push(link.workspace.as_str());
-
-                if let Some(workspace) = load_yml(workspace_path.as_path()) {
-                    let workspace = workspace?;
-                    if let Config::Workspace(workspace) = workspace {
-                        if let Some(tab) = workspace_tab(workspace_path.as_path(), &workspace) {
-                            target.tabs.push(tab);
-                        }
-                    }
-                }
-            }
-
-            WorkspaceItem::Repo(repo) => {
-                let mut repo_path = path.to_path_buf();
-                repo_path.push(repo.repo.as_str());
-                if let Some(repo) = load_yml(repo_path.as_path()) {
-                    let repo = repo?;
-                    if let Config::Repo(repo) = repo {
-                        target.repos.push((repo_path, repo));
-                    }
-                } else if repo_path.exists() {
-                    let tab = WorkspaceTab::new(repo.repo.as_str(), repo_path);
-                    target.tabs.push(tab);
-                }
-            }
-
-            WorkspaceItem::Tab(tab) => {
-                let mut directory = path.to_path_buf();
-
-                if let Some(ref dir) = tab.dir {
-                    directory.push(dir);
-                }
-
-                let options = tab.options.clone().or(workspace.options.clone());
-
-                let tab = WorkspaceTab::with_options(tab.tab.as_str(), directory, options);
-                target.tabs.push(tab);
-            }
-        }
-    }
-
-    Ok(())
-}
-
-fn workspace_tab(path: &Path, workspace: &Workspace) -> Option<WorkspaceTab> {
-    workspace_tab_name(path, &workspace)
-        .map(|name| {
-            WorkspaceTab::with_options(name.as_str(), path.to_owned(), workspace.options.clone())
-        })
-        .map(|mut tab| {
-            tab.doc = Some(workspace_tab_doc(path, workspace));
-            tab
-        })
-}
-
-fn workspace_tab_name(path: &Path, workspace: &Workspace) -> Option<String> {
-    if let Some(ref tab) = workspace.tab {
-        return Some(tab.clone());
-    }
-
-    path.file_name()
-        .map(|name| name.to_string_lossy().to_string())
-}
-
-fn workspace_tab_doc(path: &Path, workspace: &Workspace) -> String {
-    if let Some(ref doc) = workspace.options.doc {
-        return doc.clone();
-    }
-
-    if let Some(name) = path.file_name() {
-        format!("workspace tab for {}", name.to_string_lossy())
-    } else {
-        format!("workspace tab")
-    }
-}
-
-fn tabs(mut loader: LoaderState) -> Vec<WorkspaceTab> {
-    let mut tabs = Vec::new();
-    tabs.append(&mut loader.tabs);
-
-    for (path, repo) in loader.repos.into_iter() {
-        let repo_name = normalize_name(repo.repo.as_str());
-
-        // push a tab for the repo
-        let tab =
-            WorkspaceTab::with_options(repo_name.as_str(), path.clone(), repo.tab_options.clone());
-        tabs.push(tab);
-
-        // and then for any tabs the user defined
-        for tab in repo.tabs.into_iter().flat_map(|t| t.into_iter()) {
-            let mut directory = path.to_path_buf();
-            if let Some(subdir) = tab.dir {
-                directory.push(subdir);
-            }
-
-            let tab_name = normalize_name(tab.tab.as_str());
-            let tab_name = repo_name.clone() + tab_name.as_str();
-
-            let options = tab.options.or(repo.tab_options.clone());
-
-            let tab = WorkspaceTab::with_options(tab_name.as_str(), directory, options);
-            tabs.push(tab);
-        }
-    }
-
-    tabs
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{load_state_in, tabs};
     use crate::state::workspace::WorkspaceTab;
     use anyhow::bail;
     use pretty_assertions::assert_eq;
     use std::{collections::HashMap, path::PathBuf};
+
+    use super::loader::scan_config;
 
     fn test_dir(name: &str) -> anyhow::Result<PathBuf> {
         let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -270,19 +57,18 @@ mod tests {
 
     fn load(name: &str) -> anyhow::Result<(PathBuf, Vec<WorkspaceTab>)> {
         let path = test_dir(name)?;
-        let state = load_state_in(path.as_path(), Some(path.as_path()))?;
-        let tabs = tabs(state);
+        let tabs = scan_config(path.as_path(), Some(path.as_path())).unwrap();
         Ok((path, tabs))
     }
 
-    fn convert_env(map: HashMap<&str, &str>) -> Option<HashMap<String, String>> {
+    fn convert_env(map: HashMap<&str, &str>) -> HashMap<String, String> {
         let mut output = HashMap::with_capacity(map.len());
 
         for (k, v) in map.into_iter() {
             output.insert(k.into(), v.into());
         }
 
-        Some(output)
+        output
     }
 
     macro_rules! env {
@@ -295,13 +81,13 @@ mod tests {
 
     macro_rules! doc {
         ( $doc:expr ) => {
-            Some($doc.into())
+            $doc.into()
         };
     }
 
     macro_rules! shell {
         ( $doc:expr ) => {
-            Some($doc.into())
+            $doc.into()
         };
     }
 
@@ -335,7 +121,6 @@ mod tests {
                 .build(),
             WorkspaceTab::builder()
                 .name("project/".into())
-                .doc(None)
                 .directory(dir!(dir, "project"))
                 .build(),
         ];
@@ -546,8 +331,7 @@ mod tests {
     fn workspace_nested_test() -> anyhow::Result<()> {
         let outer = test_dir("workspace-nested/")?;
         let inner = test_dir("workspace-nested/sub-workspace/")?;
-        let loader_state = load_state_in(inner.as_path(), Some(outer.as_path()))?;
-        let tabs = tabs(loader_state);
+        let tabs = scan_config(inner.as_path(), Some(outer.as_path())).unwrap();
 
         let expected = vec![
             WorkspaceTab::builder()

--- a/tab-command/src/service/tab/workspace/loader.rs
+++ b/tab-command/src/service/tab/workspace/loader.rs
@@ -1,0 +1,139 @@
+use std::{fs::File, io::BufReader, path::Path};
+
+use anyhow::Context;
+use log::error;
+
+use crate::state::workspace::{Config, WorkspaceTab};
+
+use super::{repo::repo_iter, workspace::workspace_iter};
+
+pub struct TabIter {
+    elems: Vec<anyhow::Result<WorkspaceTab>>,
+}
+
+impl TabIter {
+    pub fn new() -> TabIter {
+        Self { elems: Vec::new() }
+    }
+
+    pub fn and(&mut self, elem: WorkspaceTab) -> &mut Self {
+        self.elems.push(Ok(elem));
+        self
+    }
+
+    pub fn and_err(&mut self, err: anyhow::Error) -> &mut Self {
+        self.elems.push(Err(err));
+        self
+    }
+
+    pub fn append(&mut self, mut iter: TabIter) -> &mut Self {
+        self.elems.append(&mut iter.elems);
+        self
+    }
+
+    #[cfg(test)]
+    pub fn unwrap(self) -> Vec<WorkspaceTab> {
+        let mut tabs = Vec::with_capacity(self.elems.len());
+
+        for elem in self.elems {
+            let elem = elem.unwrap();
+            tabs.push(elem);
+        }
+
+        tabs
+    }
+
+    pub fn unwrap_log(self) -> Vec<WorkspaceTab> {
+        let mut tabs = Vec::with_capacity(self.elems.len());
+
+        for elem in self.elems {
+            if let Err(e) = elem {
+                error!("Failed to load workspace entry: {}", e);
+                continue;
+            }
+
+            let elem = elem.unwrap();
+            tabs.push(elem);
+        }
+
+        tabs
+    }
+}
+
+impl IntoIterator for TabIter {
+    type Item = anyhow::Result<WorkspaceTab>;
+    type IntoIter = std::vec::IntoIter<anyhow::Result<WorkspaceTab>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.elems.into_iter()
+    }
+}
+
+pub fn scan_config(dir: &Path, base: Option<&Path>) -> TabIter {
+    let mut iter = TabIter::new();
+    let mut working_dir = Some(dir);
+
+    while let Some(dir) = working_dir {
+        if let Some(base) = base {
+            if dir != base && base.starts_with(dir) {
+                break;
+            }
+        }
+
+        let config = load_yml(dir);
+
+        if config.is_none() {
+            working_dir = dir.parent();
+            continue;
+        }
+
+        let config = config
+            .unwrap()
+            .context(format!("Loading {}/tab.yml", dir.to_string_lossy()));
+
+        if let Err(e) = config {
+            iter.and_err(e);
+            working_dir = dir.parent();
+            continue;
+        }
+
+        let config = config.unwrap();
+
+        let items = match config {
+            Config::Workspace(workspace) => workspace_iter(dir, workspace),
+            Config::Repo(repo) => repo_iter(dir, repo),
+        };
+
+        iter.append(items);
+
+        working_dir = dir.parent();
+    }
+
+    iter
+}
+
+pub fn load_yml(dir: &Path) -> Option<anyhow::Result<Config>> {
+    let mut path_buf = dir.to_owned();
+    path_buf.push("tab.yml");
+
+    if path_buf.is_file() {
+        return Some(load_file(path_buf.as_path()));
+    }
+
+    let mut path_buf = dir.to_owned();
+    path_buf.push(".tab.yml");
+
+    if path_buf.is_file() {
+        return Some(load_file(path_buf.as_path()));
+    }
+
+    None
+}
+
+fn load_file(path: &Path) -> anyhow::Result<Config> {
+    // TODO: figure out how to get rid fo the blocking IO
+    let reader = File::open(path)?;
+    let buf_reader = BufReader::new(reader);
+    let config = serde_yaml::from_reader(buf_reader)?;
+    Ok(config)
+}

--- a/tab-command/src/service/tab/workspace/repo.rs
+++ b/tab-command/src/service/tab/workspace/repo.rs
@@ -1,0 +1,39 @@
+use std::path::Path;
+
+use tab_api::tab::normalize_name;
+
+use crate::state::workspace::{Repo, WorkspaceTab};
+
+use super::loader::TabIter;
+
+pub fn repo_iter(path: &Path, repo: Repo) -> TabIter {
+    let mut iter = TabIter::new();
+
+    let repo_name = normalize_name(repo.repo.as_str());
+
+    // push a tab for the repo
+    let tab = WorkspaceTab::with_options(
+        repo_name.as_str(),
+        path.to_path_buf(),
+        repo.tab_options.clone(),
+    );
+    iter.and(tab);
+
+    // and then for any tabs the user defined
+    for tab in repo.tabs.into_iter().flat_map(|t| t.into_iter()) {
+        let mut directory = path.to_path_buf();
+        if let Some(subdir) = tab.dir {
+            directory.push(subdir);
+        }
+
+        let tab_name = normalize_name(tab.tab.as_str());
+        let tab_name = repo_name.clone() + tab_name.as_str();
+
+        let options = tab.options.or(repo.tab_options.clone());
+
+        let tab = WorkspaceTab::with_options(tab_name.as_str(), directory, options);
+        iter.and(tab);
+    }
+
+    iter
+}

--- a/tab-command/src/service/tab/workspace/workspace.rs
+++ b/tab-command/src/service/tab/workspace/workspace.rs
@@ -1,0 +1,115 @@
+use std::path::Path;
+
+use crate::state::workspace::{Config, Workspace, WorkspaceItem, WorkspaceTab};
+
+use super::{
+    loader::{load_yml, TabIter},
+    repo::repo_iter,
+};
+use anyhow::anyhow;
+
+pub fn workspace_iter(path: &Path, workspace: Workspace) -> TabIter {
+    let mut iter = TabIter::new();
+
+    if let Some(tab) = workspace_tab(path, &workspace) {
+        iter.and(tab);
+    }
+
+    for item in workspace.workspace.iter() {
+        match item {
+            WorkspaceItem::Workspace(link) => {
+                let mut workspace_path = path.to_path_buf();
+                workspace_path.push(link.workspace.as_str());
+
+                if let Some(workspace) = load_yml(workspace_path.as_path()) {
+                    if let Err(e) = workspace {
+                        iter.and_err(e.context(format!(
+                            "Loading workspace: {}/tab.yml",
+                            workspace_path.to_string_lossy()
+                        )));
+                        continue;
+                    }
+
+                    let workspace = workspace.unwrap();
+
+                    if let Config::Workspace(workspace) = workspace {
+                        if let Some(tab) = workspace_tab(workspace_path.as_path(), &workspace) {
+                            iter.and(tab);
+                        }
+                    }
+                }
+            }
+
+            WorkspaceItem::Repo(repo) => {
+                let mut repo_path = path.to_path_buf();
+                repo_path.push(repo.repo.as_str());
+                if let Some(repo) = load_yml(repo_path.as_path()) {
+                    if let Err(e) = repo {
+                        iter.and_err(e);
+                        continue;
+                    }
+
+                    let repo = repo.unwrap();
+                    if let Config::Repo(repo) = repo {
+                        iter.append(repo_iter(repo_path.as_path(), repo));
+                    } else {
+                        iter.and_err(anyhow!(
+                            "Expected a repository config at path: {}",
+                            repo_path.to_string_lossy()
+                        ));
+                    }
+                } else if repo_path.exists() {
+                    let tab = WorkspaceTab::new(repo.repo.as_str(), repo_path);
+                    iter.and(tab);
+                }
+            }
+
+            WorkspaceItem::Tab(tab) => {
+                let mut directory = path.to_path_buf();
+
+                if let Some(ref dir) = tab.dir {
+                    directory.push(dir);
+                }
+
+                let options = tab.options.clone().or(workspace.options.clone());
+
+                let tab = WorkspaceTab::with_options(tab.tab.as_str(), directory, options);
+                iter.and(tab);
+            }
+        }
+    }
+
+    iter
+}
+
+fn workspace_tab(path: &Path, workspace: &Workspace) -> Option<WorkspaceTab> {
+    workspace_tab_name(path, &workspace)
+        .map(|name| {
+            WorkspaceTab::with_options(name.as_str(), path.to_owned(), workspace.options.clone())
+        })
+        .map(|mut tab| {
+            tab.doc = Some(workspace_tab_doc(path, workspace));
+            tab
+        })
+}
+
+fn workspace_tab_name(path: &Path, workspace: &Workspace) -> Option<String> {
+    if let Some(ref tab) = workspace.tab {
+        return Some(tab.clone());
+    }
+
+    path.file_name()
+        .map(|name| name.to_string_lossy().to_string())
+}
+
+fn workspace_tab_doc(path: &Path, workspace: &Workspace) -> String {
+    if let Some(ref doc) = workspace.options.doc {
+        return doc.clone();
+    }
+
+    if let Some(name) = path.file_name() {
+        format!("workspace tab for {}", name.to_string_lossy())
+    } else {
+        format!("workspace tab")
+    }
+}

--- a/tab-command/src/state/workspace.rs
+++ b/tab-command/src/state/workspace.rs
@@ -47,12 +47,12 @@ impl WorkspaceState {
 #[derive(TypedBuilder, Debug, Clone, Eq, PartialEq)]
 pub struct WorkspaceTab {
     pub name: String,
-    #[builder(default)]
+    #[builder(default, setter(strip_option))]
     pub doc: Option<String>,
     pub directory: PathBuf,
-    #[builder(default)]
+    #[builder(default, setter(strip_option))]
     pub shell: Option<String>,
-    #[builder(default)]
+    #[builder(default, setter(strip_option))]
     pub env: Option<HashMap<String, String>>, // pub command: Option<String>,
 }
 

--- a/tab-command/test_resources/dir/tab.yml
+++ b/tab-command/test_resources/dir/tab.yml
@@ -1,6 +1,6 @@
 workspace:
-    - repo: project
     - tab: workspace-exists
       dir: project
     - tab: workspace-not-exists
       dir: not-exists
+    - repo: project

--- a/tab-command/test_resources/doc/tab.yml
+++ b/tab-command/test_resources/doc/tab.yml
@@ -1,5 +1,5 @@
 doc: "doc workspace"
 workspace:
-    - repo: project
     - tab: workspace-tab
       doc: "doc workspace tab"
+    - repo: project

--- a/tab-command/test_resources/env/tab.yml
+++ b/tab-command/test_resources/env/tab.yml
@@ -3,8 +3,8 @@ env:
     override: base
 
 workspace:
-    - repo: project
     - tab: workspace-tab
       env:
         override: override
         unique: unique
+    - repo: project

--- a/tab-command/test_resources/shell/tab.yml
+++ b/tab-command/test_resources/shell/tab.yml
@@ -1,7 +1,7 @@
 shell: workspace-shell
 
 workspace:
-    - repo: project
     - tab: workspace-inherit
     - tab: workspace-override
       shell: workspace-override-shell
+    - repo: project


### PR DESCRIPTION
Split up the workspace loader, and write a TabIter to clean up the code