### PR TITLE
Implement `tab --check`, a workspace validation utility

### DIFF
--- a/common/tab-api/src/tab.rs
+++ b/common/tab-api/src/tab.rs
@@ -13,6 +13,22 @@ pub fn normalize_name(name: &str) -> String {
     }
 }
 
+pub fn validate_tab_name(name: String) -> Result<(), String> {
+    if name.starts_with('-') {
+        return Err("tab name may not begin with a dash".into());
+    }
+
+    if name.contains(' ') || name.contains('\t') || name.contains('\r') || name.contains('\n') {
+        return Err("tab name may not contain whitespace".into());
+    }
+
+    if name.contains('\\') {
+        return Err("tab name may not contain backslashes".into());
+    }
+
+    Ok(())
+}
+
 /// Identifies a running tab using a numeric index.
 #[derive(Serialize, Deserialize, Copy, Clone, Debug, Hash, PartialEq, Eq)]
 pub struct TabId(pub u16);

--- a/tab-command/src/lib.rs
+++ b/tab-command/src/lib.rs
@@ -52,13 +52,15 @@ pub fn command_main(args: ArgMatches, tab_version: &'static str) -> anyhow::Resu
 }
 
 async fn main_async(matches: ArgMatches<'_>, tab_version: &'static str) -> anyhow::Result<()> {
-    let select_tab = matches.value_of("TAB-NAME");
-    let close_tabs = matches.values_of("CLOSE-TAB");
-    let disconnect_tabs = matches.values_of("DISCONNECT-TAB");
-    let (mut tx, rx_shutdown, _service) = spawn(tab_version).await?;
-    let completion = matches.is_present("AUTOCOMPLETE-TAB");
+    let check_workspace = matches.is_present("CHECK-WORKSPACE");
     let close_completion = matches.is_present("AUTOCOMPLETE-CLOSE-TAB");
+    let close_tabs = matches.values_of("CLOSE-TAB");
+    let completion = matches.is_present("AUTOCOMPLETE-TAB");
+    let disconnect_tabs = matches.values_of("DISCONNECT-TAB");
+    let select_tab = matches.value_of("TAB-NAME");
     let shutdown = matches.is_present("SHUTDOWN");
+
+    let (mut tx, rx_shutdown, _service) = spawn(tab_version).await?;
 
     if shutdown {
         tx.send(MainRecv::GlobalShutdown).await?;
@@ -66,6 +68,8 @@ async fn main_async(matches: ArgMatches<'_>, tab_version: &'static str) -> anyho
         tx.send(MainRecv::AutocompleteTab).await?;
     } else if close_completion {
         tx.send(MainRecv::AutocompleteCloseTab).await?;
+    } else if check_workspace {
+        tx.send(MainRecv::CheckWorkspace).await?;
     } else if matches.is_present("LIST") {
         tx.send(MainRecv::ListTabs).await?;
     } else if let Some(tab) = select_tab {

--- a/tab-command/src/message/main.rs
+++ b/tab-command/src/message/main.rs
@@ -8,14 +8,15 @@ pub struct MainShutdown {}
 
 #[derive(Debug, Clone)]
 pub enum MainRecv {
-    SelectTab(String),
-    SelectInteractive,
-    ListTabs,
-    DisconnectTabs(Vec<String>),
-    CloseTabs(Vec<String>),
-    AutocompleteTab,
     AutocompleteCloseTab,
+    AutocompleteTab,
+    CheckWorkspace,
+    CloseTabs(Vec<String>),
+    DisconnectTabs(Vec<String>),
     GlobalShutdown,
+    ListTabs,
+    SelectInteractive,
+    SelectTab(String),
 }
 
 #[derive(Debug)]

--- a/tab-command/src/service/main.rs
+++ b/tab-command/src/service/main.rs
@@ -1,9 +1,9 @@
 use self::{
     autocomplete_close_tab::MainAutocompleteCloseTabsService,
-    autocomplete_tab::MainAutocompleteTabsService, close_tabs::MainCloseTabsService,
-    disconnect_tabs::MainDisconnectTabsService, global_shutdown::MainGlobalShutdownService,
-    list_tabs::MainListTabsService, select_interactive::MainSelectInteractiveService,
-    select_tab::MainSelectTabService,
+    autocomplete_tab::MainAutocompleteTabsService, check_workspace::MainCheckWorkspaceService,
+    close_tabs::MainCloseTabsService, disconnect_tabs::MainDisconnectTabsService,
+    global_shutdown::MainGlobalShutdownService, list_tabs::MainListTabsService,
+    select_interactive::MainSelectInteractiveService, select_tab::MainSelectTabService,
 };
 
 use super::{
@@ -24,6 +24,7 @@ use tab_websocket::{
 
 mod autocomplete_close_tab;
 mod autocomplete_tab;
+mod check_workspace;
 mod close_tabs;
 mod disconnect_tabs;
 mod global_shutdown;
@@ -33,14 +34,15 @@ mod select_tab;
 
 /// Launches the tab-command client, including websocket, tab state, and terminal services.
 pub struct MainService {
-    _main_autocomplete_close: MainAutocompleteCloseTabsService,
     _main_autocomplete: MainAutocompleteTabsService,
+    _main_autocomplete_close: MainAutocompleteCloseTabsService,
     _main_close_tabs: MainCloseTabsService,
+    _main_check_workspace: MainCheckWorkspaceService,
     _main_disconnect_tabs: MainDisconnectTabsService,
+    _main_global_shutdown: MainGlobalShutdownService,
     _main_list_tabs: MainListTabsService,
     _main_select_interactive: MainSelectInteractiveService,
     _main_select_tab: MainSelectTabService,
-    _main_global_shutdown: MainGlobalShutdownService,
     _main_tab: MainTabCarrier,
     _main_websocket: WebsocketCarrier,
     _select_tab: SelectTabService,
@@ -56,14 +58,15 @@ impl Service for MainService {
     type Lifeline = anyhow::Result<Self>;
 
     fn spawn(main_bus: &MainBus) -> anyhow::Result<Self> {
-        let _main_autocomplete_close = MainAutocompleteCloseTabsService::spawn(main_bus)?;
         let _main_autocomplete = MainAutocompleteTabsService::spawn(main_bus)?;
+        let _main_autocomplete_close = MainAutocompleteCloseTabsService::spawn(main_bus)?;
+        let _main_check_workspace = MainCheckWorkspaceService::spawn(main_bus)?;
         let _main_close_tabs = MainCloseTabsService::spawn(main_bus)?;
         let _main_disconnect_tabs = MainDisconnectTabsService::spawn(main_bus)?;
+        let _main_global_shutdown = MainGlobalShutdownService::spawn(main_bus)?;
         let _main_list_tabs = MainListTabsService::spawn(main_bus)?;
         let _main_select_interactive = MainSelectInteractiveService::spawn(main_bus)?;
         let _main_select_tab = MainSelectTabService::spawn(main_bus)?;
-        let _main_global_shutdown = MainGlobalShutdownService::spawn(main_bus)?;
 
         let tab_bus = TabBus::default();
         tab_bus.capacity::<TabMetadata>(256)?;
@@ -83,14 +86,15 @@ impl Service for MainService {
         let _terminal = TerminalService::spawn(&main_bus)?;
 
         Ok(Self {
-            _main_autocomplete_close,
             _main_autocomplete,
+            _main_autocomplete_close,
+            _main_check_workspace,
             _main_close_tabs,
             _main_disconnect_tabs,
+            _main_global_shutdown,
             _main_list_tabs,
             _main_select_interactive,
             _main_select_tab,
-            _main_global_shutdown,
             _main_tab,
             _main_websocket,
             _select_tab,

--- a/tab-command/src/service/main/check_workspace.rs
+++ b/tab-command/src/service/main/check_workspace.rs
@@ -1,0 +1,53 @@
+use crate::{
+    message::main::MainRecv, message::main::MainShutdown, prelude::*,
+    state::workspace::WorkspaceState, utils::await_state,
+};
+
+pub struct MainCheckWorkspaceService {
+    _run: Lifeline,
+}
+
+impl Service for MainCheckWorkspaceService {
+    type Bus = MainBus;
+    type Lifeline = anyhow::Result<Self>;
+
+    fn spawn(bus: &Self::Bus) -> Self::Lifeline {
+        let mut rx = bus.rx::<MainRecv>()?;
+        let mut rx_workspace = bus.rx::<Option<WorkspaceState>>()?.into_inner();
+
+        let mut tx_shutdown = bus.tx::<MainShutdown>()?;
+
+        let _run = Self::try_task("run", async move {
+            while let Some(msg) = rx.recv().await {
+                if let MainRecv::CheckWorkspace = msg {
+                    let workspace = await_state(&mut rx_workspace).await?;
+
+                    Self::echo_errors(&workspace.errors);
+                    tx_shutdown.send(MainShutdown {}).await.ok();
+                    break;
+                }
+            }
+
+            Ok(())
+        });
+
+        Ok(Self { _run })
+    }
+}
+
+impl MainCheckWorkspaceService {
+    fn echo_errors(errors: &Vec<String>) {
+        if errors.len() == 0 {
+            eprintln!("No errors detected.");
+            return;
+        } else if errors.len() == 1 {
+            eprintln!("{} error was detected:", errors.len());
+        } else {
+            eprintln!("{} errors were detected:", errors.len());
+        }
+
+        for error in errors {
+            eprintln!("    - {}", error);
+        }
+    }
+}

--- a/tab-command/src/service/tab/workspace/loader.rs
+++ b/tab-command/src/service/tab/workspace/loader.rs
@@ -1,36 +1,108 @@
-use std::{fs::File, io::BufReader, path::Path};
+use std::{collections::HashSet, fs::File, io::BufReader, path::Path, path::PathBuf};
 
-use anyhow::Context;
-use log::error;
+use crate::state::{
+    workspace::{Config, WorkspaceTab},
+    workspace_err::LoadYamlError,
+    workspace_err::WorkspaceError,
+    workspace_err::WorkspaceResult,
+};
 
-use crate::state::workspace::{Config, WorkspaceTab};
+use super::{repo::build_repo, workspace::build_workspace};
 
-use super::{repo::repo_iter, workspace::workspace_iter};
-
-pub struct TabIter {
-    elems: Vec<anyhow::Result<WorkspaceTab>>,
+pub struct WorkspaceBuilder {
+    elems: Vec<WorkspaceResult>,
+    tabs: HashSet<String>,
+    workspaces: HashSet<PathBuf>,
+    repos: HashSet<PathBuf>,
 }
 
-impl TabIter {
-    pub fn new() -> TabIter {
-        Self { elems: Vec::new() }
+pub struct WorkspaceTabs {
+    elems: Vec<WorkspaceResult>,
+}
+
+impl WorkspaceBuilder {
+    pub fn new() -> WorkspaceBuilder {
+        Self {
+            elems: Vec::new(),
+            tabs: HashSet::new(),
+            workspaces: HashSet::new(),
+            repos: HashSet::new(),
+        }
     }
 
-    pub fn and(&mut self, elem: WorkspaceTab) -> &mut Self {
-        self.elems.push(Ok(elem));
+    pub fn contains_workspace(&self, path: &Path) -> bool {
+        self.workspaces.contains(path)
+    }
+
+    pub fn contains_repo(&self, path: &Path) -> bool {
+        self.repos.contains(path)
+    }
+
+    pub fn workspace(&mut self, path: PathBuf) {
+        self.workspaces.insert(path);
+    }
+
+    pub fn repo(&mut self, path: PathBuf) {
+        self.repos.insert(path);
+    }
+
+    pub fn tab(&mut self, tab: WorkspaceTab) -> &mut Self {
+        if self.tabs.contains(&tab.name) {
+            self.err(WorkspaceError::duplicate_tab(tab.name));
+            return self;
+        }
+
+        self.validate(&tab);
+        self.tabs.insert(tab.name.clone());
+        self.elems.push(Ok(tab));
         self
     }
 
-    pub fn and_err(&mut self, err: anyhow::Error) -> &mut Self {
+    pub fn err(&mut self, err: WorkspaceError) -> &mut Self {
         self.elems.push(Err(err));
         self
     }
 
-    pub fn append(&mut self, mut iter: TabIter) -> &mut Self {
-        self.elems.append(&mut iter.elems);
+    pub fn result(&mut self, result: Result<WorkspaceTab, WorkspaceError>) -> &mut Self {
+        self.elems.push(result);
         self
     }
 
+    fn validate(&mut self, tab: &WorkspaceTab) {
+        if !tab.directory.exists() {
+            self.err(WorkspaceError::tab_directory_not_found(
+                tab.name.clone(),
+                tab.directory.clone(),
+            ));
+        }
+
+        if let Err(e) = validate_tab_name(tab.name.as_str()) {
+            self.err(WorkspaceError::tab_name_invalid(tab.name.clone(), e));
+        }
+    }
+
+    pub fn build(self) -> WorkspaceTabs {
+        WorkspaceTabs { elems: self.elems }
+    }
+}
+
+fn validate_tab_name(name: &str) -> Result<(), String> {
+    if name.starts_with('-') {
+        return Err("tab name may not begin with a dash".into());
+    }
+
+    if name.contains(' ') || name.contains('\t') {
+        return Err("tab name may not contain whitespace".into());
+    }
+
+    if name.contains('\\') {
+        return Err("tab name may not contain backslashes".into());
+    }
+
+    Ok(())
+}
+
+impl WorkspaceTabs {
     #[cfg(test)]
     pub fn unwrap(self) -> Vec<WorkspaceTab> {
         let mut tabs = Vec::with_capacity(self.elems.len());
@@ -43,34 +115,42 @@ impl TabIter {
         tabs
     }
 
-    pub fn unwrap_log(self) -> Vec<WorkspaceTab> {
+    pub fn ok(self) -> Vec<WorkspaceTab> {
         let mut tabs = Vec::with_capacity(self.elems.len());
 
         for elem in self.elems {
-            if let Err(e) = elem {
-                error!("Failed to load workspace entry: {}", e);
-                continue;
+            if let Ok(tab) = elem {
+                tabs.push(tab);
             }
-
-            let elem = elem.unwrap();
-            tabs.push(elem);
         }
 
         tabs
     }
+
+    pub fn errors(&self) -> Vec<&WorkspaceError> {
+        let mut errors = Vec::with_capacity(self.elems.len());
+
+        for elem in &self.elems {
+            if let Err(e) = elem {
+                errors.push(e);
+            }
+        }
+
+        errors
+    }
 }
 
-impl IntoIterator for TabIter {
-    type Item = anyhow::Result<WorkspaceTab>;
-    type IntoIter = std::vec::IntoIter<anyhow::Result<WorkspaceTab>>;
+impl IntoIterator for WorkspaceTabs {
+    type Item = WorkspaceResult;
+    type IntoIter = std::vec::IntoIter<WorkspaceResult>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.elems.into_iter()
     }
 }
 
-pub fn scan_config(dir: &Path, base: Option<&Path>) -> TabIter {
-    let mut iter = TabIter::new();
+pub fn scan_config(dir: &Path, base: Option<&Path>) -> WorkspaceTabs {
+    let mut builder = WorkspaceBuilder::new();
     let mut working_dir = Some(dir);
 
     while let Some(dir) = working_dir {
@@ -80,60 +160,87 @@ pub fn scan_config(dir: &Path, base: Option<&Path>) -> TabIter {
             }
         }
 
-        let config = load_yml(dir);
-
-        if config.is_none() {
-            working_dir = dir.parent();
-            continue;
-        }
-
-        let config = config
-            .unwrap()
-            .context(format!("Loading {}/tab.yml", dir.to_string_lossy()));
-
-        if let Err(e) = config {
-            iter.and_err(e);
-            working_dir = dir.parent();
-            continue;
-        }
-
-        let config = config.unwrap();
-
-        let items = match config {
-            Config::Workspace(workspace) => workspace_iter(dir, workspace),
-            Config::Repo(repo) => repo_iter(dir, repo),
+        match load_yml(dir) {
+            YmlResult::Ok(Config::Workspace(workspace)) => {
+                build_workspace(&mut builder, dir, workspace);
+            }
+            YmlResult::Ok(Config::Repo(repo)) => build_repo(&mut builder, dir, repo),
+            YmlResult::Ok(Config::None) => {
+                builder.err(WorkspaceError::none_error(
+                    dir.to_path_buf(),
+                    "Workspace or Repo",
+                ));
+            }
+            YmlResult::Err(err) => {
+                builder.err(WorkspaceError::load_error(err));
+            }
+            YmlResult::None(_) => {}
         };
-
-        iter.append(items);
 
         working_dir = dir.parent();
     }
 
-    iter
+    builder.build()
 }
 
-pub fn load_yml(dir: &Path) -> Option<anyhow::Result<Config>> {
+pub enum YmlResult {
+    Ok(Config),
+    Err(LoadYamlError),
+    None(PathBuf),
+}
+
+impl YmlResult {
+    pub fn required(self) -> Result<Config, LoadYamlError> {
+        match self {
+            YmlResult::Ok(config) => Ok(config),
+            YmlResult::Err(e) => Err(e),
+            YmlResult::None(path) => Err(LoadYamlError::ExpectedError(path)),
+        }
+    }
+}
+
+impl From<Result<Config, LoadYamlError>> for YmlResult {
+    fn from(result: Result<Config, LoadYamlError>) -> Self {
+        match result {
+            Ok(yml) => Self::Ok(yml),
+            Err(e) => Self::Err(e),
+        }
+    }
+}
+
+pub fn load_yml(dir: &Path) -> YmlResult {
+    let path = yml_path(dir);
+    if let None = path {
+        return YmlResult::None(dir.to_path_buf());
+    }
+
+    let path = path.unwrap();
+    load_file(path.as_path()).into()
+}
+
+fn yml_path(dir: &Path) -> Option<PathBuf> {
     let mut path_buf = dir.to_owned();
     path_buf.push("tab.yml");
 
     if path_buf.is_file() {
-        return Some(load_file(path_buf.as_path()));
+        return Some(path_buf);
     }
 
-    let mut path_buf = dir.to_owned();
-    path_buf.push(".tab.yml");
+    path_buf.pop();
 
     if path_buf.is_file() {
-        return Some(load_file(path_buf.as_path()));
+        return Some(path_buf);
     }
 
     None
 }
 
-fn load_file(path: &Path) -> anyhow::Result<Config> {
+fn load_file(path: &Path) -> Result<Config, LoadYamlError> {
     // TODO: figure out how to get rid fo the blocking IO
-    let reader = File::open(path)?;
+    let reader = File::open(path).map_err(|err| LoadYamlError::IoError(path.to_owned(), err))?;
+
     let buf_reader = BufReader::new(reader);
-    let config = serde_yaml::from_reader(buf_reader)?;
-    Ok(config)
+
+    serde_yaml::from_reader(buf_reader)
+        .map_err(|err| LoadYamlError::SerdeError(path.to_owned(), err))
 }

--- a/tab-command/src/service/tab/workspace/loader.rs
+++ b/tab-command/src/service/tab/workspace/loader.rs
@@ -140,15 +140,6 @@ impl WorkspaceTabs {
     }
 }
 
-impl IntoIterator for WorkspaceTabs {
-    type Item = WorkspaceResult;
-    type IntoIter = std::vec::IntoIter<WorkspaceResult>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.elems.into_iter()
-    }
-}
-
 pub fn scan_config(dir: &Path, base: Option<&Path>) -> WorkspaceTabs {
     let mut builder = WorkspaceBuilder::new();
     let mut working_dir = Some(dir);

--- a/tab-command/src/service/tab/workspace/workspace.rs
+++ b/tab-command/src/service/tab/workspace/workspace.rs
@@ -1,19 +1,25 @@
 use std::path::Path;
 
-use crate::state::workspace::{Config, Workspace, WorkspaceItem, WorkspaceTab};
+use log::info;
+
+use crate::state::{
+    workspace::{Workspace, WorkspaceItem, WorkspaceTab},
+    workspace_err::WorkspaceError,
+};
 
 use super::{
-    loader::{load_yml, TabIter},
-    repo::repo_iter,
+    loader::{load_yml, WorkspaceBuilder, YmlResult},
+    repo::build_repo,
 };
-use anyhow::anyhow;
 
-pub fn workspace_iter(path: &Path, workspace: Workspace) -> TabIter {
-    let mut iter = TabIter::new();
-
-    if let Some(tab) = workspace_tab(path, &workspace) {
-        iter.and(tab);
+pub fn build_workspace(builder: &mut WorkspaceBuilder, path: &Path, workspace: Workspace) {
+    if builder.contains_workspace(path) {
+        return;
     }
+
+    info!("Loading workspace: {}", path.to_string_lossy());
+
+    builder.result(workspace_tab(path, &workspace));
 
     for item in workspace.workspace.iter() {
         match item {
@@ -21,47 +27,82 @@ pub fn workspace_iter(path: &Path, workspace: Workspace) -> TabIter {
                 let mut workspace_path = path.to_path_buf();
                 workspace_path.push(link.workspace.as_str());
 
-                if let Some(workspace) = load_yml(workspace_path.as_path()) {
-                    if let Err(e) = workspace {
-                        iter.and_err(e.context(format!(
-                            "Loading workspace: {}/tab.yml",
-                            workspace_path.to_string_lossy()
-                        )));
-                        continue;
-                    }
-
-                    let workspace = workspace.unwrap();
-
-                    if let Config::Workspace(workspace) = workspace {
-                        if let Some(tab) = workspace_tab(workspace_path.as_path(), &workspace) {
-                            iter.and(tab);
-                        }
-                    }
+                if !workspace_path.exists() {
+                    builder.err(WorkspaceError::workspace_not_found(workspace_path));
+                    continue;
                 }
+
+                let workspace_path = workspace_path
+                    .canonicalize()
+                    .map_err(|err| WorkspaceError::canonicalize_error(workspace_path.clone(), err));
+
+                if let Err(e) = workspace_path {
+                    builder.err(e);
+                    continue;
+                }
+
+                let workspace_path = workspace_path.unwrap();
+
+                let workspace = load_yml(workspace_path.as_path())
+                    .required()
+                    .map_err(WorkspaceError::load_error)
+                    .and_then(|config| config.as_workspace(workspace_path.as_path()));
+
+                if let Err(e) = workspace {
+                    builder.err(e);
+                    continue;
+                }
+
+                let workspace = workspace.unwrap();
+                let tab = workspace_tab(workspace_path.as_path(), &workspace);
+                builder.result(tab);
             }
 
             WorkspaceItem::Repo(repo) => {
                 let mut repo_path = path.to_path_buf();
                 repo_path.push(repo.repo.as_str());
-                if let Some(repo) = load_yml(repo_path.as_path()) {
-                    if let Err(e) = repo {
-                        iter.and_err(e);
+
+                if !repo_path.exists() {
+                    builder.err(WorkspaceError::repo_not_found(repo_path));
+                    continue;
+                }
+
+                let repo_path = repo_path
+                    .canonicalize()
+                    .map_err(|err| WorkspaceError::canonicalize_error(repo_path.clone(), err));
+
+                if let Err(e) = repo_path {
+                    builder.err(e);
+                    continue;
+                }
+
+                let repo_path = repo_path.unwrap();
+
+                let repo = match load_yml(repo_path.as_path()) {
+                    YmlResult::Ok(config) => config.as_repo(repo_path.as_path()),
+                    YmlResult::Err(e) => {
+                        builder.err(WorkspaceError::load_error(e));
                         continue;
                     }
+                    YmlResult::None(_path) => {
+                        let tab_name = repo_tab_name(repo_path.as_path());
+                        if let Err(e) = tab_name {
+                            builder.err(e);
+                            continue;
+                        }
 
-                    let repo = repo.unwrap();
-                    if let Config::Repo(repo) = repo {
-                        iter.append(repo_iter(repo_path.as_path(), repo));
-                    } else {
-                        iter.and_err(anyhow!(
-                            "Expected a repository config at path: {}",
-                            repo_path.to_string_lossy()
-                        ));
+                        let tab = WorkspaceTab::new(tab_name.unwrap().as_str(), repo_path);
+                        builder.tab(tab);
+                        continue;
                     }
-                } else if repo_path.exists() {
-                    let tab = WorkspaceTab::new(repo.repo.as_str(), repo_path);
-                    iter.and(tab);
+                };
+
+                if let Err(e) = repo {
+                    builder.err(e);
+                    continue;
                 }
+
+                build_repo(builder, repo_path.as_path(), repo.unwrap());
             }
 
             WorkspaceItem::Tab(tab) => {
@@ -74,15 +115,15 @@ pub fn workspace_iter(path: &Path, workspace: Workspace) -> TabIter {
                 let options = tab.options.clone().or(workspace.options.clone());
 
                 let tab = WorkspaceTab::with_options(tab.tab.as_str(), directory, options);
-                iter.and(tab);
+                builder.tab(tab);
             }
         }
     }
 
-    iter
+    builder.workspace(path.to_path_buf());
 }
 
-fn workspace_tab(path: &Path, workspace: &Workspace) -> Option<WorkspaceTab> {
+fn workspace_tab(path: &Path, workspace: &Workspace) -> Result<WorkspaceTab, WorkspaceError> {
     workspace_tab_name(path, &workspace)
         .map(|name| {
             WorkspaceTab::with_options(name.as_str(), path.to_owned(), workspace.options.clone())
@@ -93,13 +134,24 @@ fn workspace_tab(path: &Path, workspace: &Workspace) -> Option<WorkspaceTab> {
         })
 }
 
-fn workspace_tab_name(path: &Path, workspace: &Workspace) -> Option<String> {
+fn workspace_tab_name(path: &Path, workspace: &Workspace) -> Result<String, WorkspaceError> {
     if let Some(ref tab) = workspace.tab {
-        return Some(tab.clone());
+        return Ok(tab.clone());
     }
 
-    path.file_name()
-        .map(|name| name.to_string_lossy().to_string())
+    if let Some(file_name) = path.file_name() {
+        return Ok(file_name.to_string_lossy().to_string());
+    }
+
+    Err(WorkspaceError::workspace_tab_name_error(path.to_path_buf()))
+}
+
+fn repo_tab_name(path: &Path) -> Result<String, WorkspaceError> {
+    if let Some(file_name) = path.file_name() {
+        return Ok(file_name.to_string_lossy().to_string());
+    }
+
+    Err(WorkspaceError::repo_tab_name_error(path.to_path_buf()))
 }
 
 fn workspace_tab_doc(path: &Path, workspace: &Workspace) -> String {

--- a/tab-command/src/state.rs
+++ b/tab-command/src/state.rs
@@ -3,3 +3,4 @@ pub mod tab;
 pub mod tabs;
 pub mod terminal;
 pub mod workspace;
+pub mod workspace_err;

--- a/tab-command/src/state/workspace_err.rs
+++ b/tab-command/src/state/workspace_err.rs
@@ -1,0 +1,155 @@
+use std::path::PathBuf;
+use thiserror::Error;
+
+use super::workspace::WorkspaceTab;
+
+pub type WorkspaceResult = std::result::Result<WorkspaceTab, WorkspaceError>;
+
+#[derive(Error, Debug)]
+pub enum WorkspaceError {
+    #[error("{0}")]
+    ConfigVariantError(ConfigVariantError),
+    #[error("{0}")]
+    NoConfigVariant(NoConfigVariantError),
+
+    #[error("{0}")]
+    WorkspaceNotFound(WorkspaceNotFoundError),
+    #[error("{0}")]
+    WorkspaceTabNameError(WorkspaceTabNameError),
+
+    #[error("{0}")]
+    RepoNotFound(RepoNotFoundError),
+    #[error("{0}")]
+    RepoTabNameError(RepoTabNameError),
+
+    #[error("{0}")]
+    CanonicalizeError(CanonicalizeError),
+    #[error("{0}")]
+    LoadYamlError(LoadYamlError),
+
+    #[error("{0}")]
+    TabDirectoryNotFound(TabDirectoryNotFoundError),
+
+    #[error("{0}")]
+    TabNameInvalid(TabNameInvalidError),
+    #[error("{0}")]
+    TabDuplicate(TabDuplicateError),
+}
+
+impl WorkspaceError {
+    pub fn canonicalize_error(path: PathBuf, err: std::io::Error) -> Self {
+        Self::CanonicalizeError(CanonicalizeError { path, err })
+    }
+
+    pub fn none_error(path: PathBuf, expected: &'static str) -> Self {
+        Self::NoConfigVariant(NoConfigVariantError { path, expected })
+    }
+
+    pub fn load_error(err: LoadYamlError) -> Self {
+        Self::LoadYamlError(err)
+    }
+
+    pub fn workspace_not_found(path: PathBuf) -> Self {
+        Self::WorkspaceNotFound(WorkspaceNotFoundError { path })
+    }
+
+    pub fn workspace_tab_name_error(path: PathBuf) -> Self {
+        Self::WorkspaceTabNameError(WorkspaceTabNameError { path })
+    }
+
+    pub fn repo_not_found(path: PathBuf) -> Self {
+        Self::RepoNotFound(RepoNotFoundError { path })
+    }
+
+    pub fn repo_tab_name_error(path: PathBuf) -> Self {
+        Self::RepoTabNameError(RepoTabNameError { path })
+    }
+
+    pub fn tab_directory_not_found(tab: String, path: PathBuf) -> Self {
+        Self::TabDirectoryNotFound(TabDirectoryNotFoundError { tab, path })
+    }
+
+    pub fn tab_name_invalid(tab: String, reason: String) -> Self {
+        Self::TabNameInvalid(TabNameInvalidError { tab, reason })
+    }
+
+    pub fn duplicate_tab(tab: String) -> Self {
+        Self::TabDuplicate(TabDuplicateError { tab })
+    }
+}
+
+#[derive(Error, Debug)]
+#[error("Could not canonicalize path: {path}, error: {err}")]
+pub struct CanonicalizeError {
+    path: PathBuf,
+    err: std::io::Error,
+}
+
+#[derive(Error, Debug)]
+#[error("Workspace path does not exist: {path}")]
+pub struct WorkspaceNotFoundError {
+    pub path: PathBuf,
+}
+
+#[derive(Error, Debug)]
+#[error("Workspace config has no 'tab' property, and no directory name could be resolved: {path}")]
+pub struct WorkspaceTabNameError {
+    path: PathBuf,
+}
+
+#[derive(Error, Debug)]
+#[error(
+    "Repository config has no 'repo' property, and no directory name could be resolved: {path}"
+)]
+pub struct RepoTabNameError {
+    path: PathBuf,
+}
+
+#[derive(Error, Debug)]
+pub enum LoadYamlError {
+    #[error("Failed to load config at path: {0} - error: {1}")]
+    IoError(PathBuf, std::io::Error),
+    #[error("Failed to deserialize config at path: {0} - error: {1}")]
+    SerdeError(PathBuf, serde_yaml::Error),
+    #[error("Expected 'tab.yml' within directory: {0}")]
+    ExpectedError(PathBuf),
+}
+
+#[derive(Error, Debug)]
+#[error("Expected {expected} config, but found {found}")]
+pub struct ConfigVariantError {
+    pub path: PathBuf,
+    pub expected: &'static str,
+    pub found: &'static str,
+}
+
+#[derive(Error, Debug)]
+#[error("Repository path does not exist: {path}")]
+pub struct RepoNotFoundError {
+    pub path: PathBuf,
+}
+
+#[derive(Error, Debug)]
+#[error("Expected {expected} config, but none could be parsed.  Add 'repo: name' or 'workspace: [entries...]' so this config can be parsed")]
+pub struct NoConfigVariantError {
+    pub path: PathBuf,
+    pub expected: &'static str,
+}
+#[derive(Error, Debug)]
+#[error("Tab {tab} has a working directory that does not exist: {path}")]
+pub struct TabDirectoryNotFoundError {
+    pub tab: String,
+    pub path: PathBuf,
+}
+
+#[derive(Error, Debug)]
+#[error("Tab {tab} has an invalid name: {reason}")]
+pub struct TabNameInvalidError {
+    pub tab: String,
+    pub reason: String,
+}
+#[derive(Error, Debug)]
+#[error("Tab {tab} has duplicate definitions")]
+pub struct TabDuplicateError {
+    pub tab: String,
+}

--- a/tab/src/cli.rs
+++ b/tab/src/cli.rs
@@ -62,6 +62,13 @@ fn app() -> App<'static, 'static> {
                 .help("Automatically installs completions & statusline integrations."),
         )
         .arg(
+            Arg::with_name("CHECK-WORKSPACE")
+                .long("check")
+                .short("-k")
+                .required(false)
+                .help("Checks the current workspace (tab.yml) for errors and warnings."),
+        )
+        .arg(
             Arg::with_name("LOG")
                 .long("log")
                 .required(false)

--- a/tab/src/completions/bash/tab.bash
+++ b/tab/src/completions/bash/tab.bash
@@ -39,7 +39,7 @@ _tab() {
         return 0
         ;;
     -*)
-        opts=" -h --help -l --list -w --close -z --disconnect -W --shutdown -V --version --completion <TAB> "
+        opts=" -h --help -l --list -w --close -z --disconnect -k --check -W --shutdown -V --version --completion <TAB> "
         COMPREPLY=( $(compgen -W "${opts}" -- $cur) )
         return 0
         ;;

--- a/tab/src/completions/fish/tab.fish
+++ b/tab/src/completions/fish/tab.fish
@@ -6,6 +6,7 @@ complete -c tab -n "__fish_use_subcommand" -o w -l close -d 'closes the tab with
 complete -c tab -n "__fish_use_subcommand" -o z -l disconnect -d 'disconnects any active sessions for the given tab' -x -a '(tab --_autocomplete_close_tab)'
 
 complete -c tab -l completion -d 'prints raw autocomplete scripts' -x -a 'bash elvish fish powershell zsh'
+complete -c tab -n "__fish_use_subcommand" -s k -l check -d 'checks the current workspace for errors and warnings'
 complete -c tab -n "__fish_use_subcommand" -s l -l list -d 'lists the active tabs'
 complete -c tab -n "__fish_use_subcommand" -s W -l shutdown -d 'terminates the tab daemon and all active pty sessions'
 complete -c tab -n "__fish_use_subcommand" -s h -l help -d 'Prints help information'

--- a/tab/src/completions/zsh/_tab
+++ b/tab/src/completions/zsh/_tab
@@ -17,6 +17,8 @@ function _tab() {
         '--disconnect=[disconnects any active sessions for the given tab]:close:($(_tab_close))'\
         '-l[lists the active tabs]' \
         '--list[lists the active tabs]' \
+        '-k[checks the current workspace for errors and warnings]' \
+        '--check[checks the current workspace for errors and warnings]' \
         '-W[terminates the tab daemon and all active pty sessions]' \
         '--shutdown[terminates the tab daemon and all active pty sessions]' \
         '--completion=[prints raw autocomplete scripts]: :(bash elvish fish powershell zsh)' \


### PR DESCRIPTION
Implement `tab --check`, a utility that prints errors and warnings about tab.yml configurations.

Example:
```
$ tab --check
4 errors were detected:
    - Tab tab/foo/ has a working directory that does not exist: /Users/austinjones/workspace/tab-rs/not-exists/
    - Workspace path does not exist: /Users/austinjones/workspace/../not-exists
    - Repository path does not exist: /Users/austinjones/workspace/not-exists
    - Tab duplicate/ has duplicate definitions
```