### PR TITLE
Support exit codes in tab-command, and return 1 if close or disconnect have no args

### DIFF
--- a/common/tab-api/src/launch.rs
+++ b/common/tab-api/src/launch.rs
@@ -106,14 +106,14 @@ pub fn launch_pty() -> anyhow::Result<()> {
 /// Waits for either a ctrl-c signal, or a message on the given channel.
 ///
 /// Useful in main() functions.
-pub async fn wait_for_shutdown<T>(mut receiver: impl Receiver<T>) {
+pub async fn wait_for_shutdown<T: Default>(mut receiver: impl Receiver<T>) -> T {
     loop {
         select! {
             _ = ctrl_c() => {
-                break;
+                return T::default();
             },
-            _ = receiver.recv() => {
-                break;
+            msg = receiver.recv() => {
+                return msg.unwrap_or(T::default());
             }
         }
     }

--- a/tab-command/src/bus/tab.rs
+++ b/tab-command/src/bus/tab.rs
@@ -137,7 +137,7 @@ impl CarryFrom<MainBus> for TabBus {
             let mut tx = from.tx::<MainShutdown>()?;
             Self::try_task("forward_shutdown", async move {
                 rx.recv().await;
-                tx.send(MainShutdown {}).await.ok();
+                tx.send(MainShutdown(0)).await.ok();
                 Ok(())
             })
         };
@@ -201,7 +201,7 @@ impl CarryFrom<MainBus> for TabBus {
                             time::delay_for(Duration::from_millis(25)).await;
 
                             tx_shutdown
-                                .send(MainShutdown {})
+                                .send(MainShutdown(0))
                                 .await
                                 .context("tx MainShutdown")?;
                         }
@@ -212,7 +212,7 @@ impl CarryFrom<MainBus> for TabBus {
                         Response::Disconnect => {
                             eprintln!("\r\nTab disconnected.");
                             tx_shutdown
-                                .send(MainShutdown {})
+                                .send(MainShutdown(0))
                                 .await
                                 .context("tx MainShutdown")?;
                         }
@@ -220,7 +220,7 @@ impl CarryFrom<MainBus> for TabBus {
                     }
                 }
 
-                tx_shutdown.send(MainShutdown {}).await?;
+                tx_shutdown.send(MainShutdown(0)).await?;
 
                 Ok(())
             })

--- a/tab-command/src/bus/terminal.rs
+++ b/tab-command/src/bus/terminal.rs
@@ -103,7 +103,7 @@ impl CarryFrom<MainBus> for TerminalBus {
 
             Self::try_task("forward_shutdown", async move {
                 if let Some(_shutdown) = rx_shutdown.recv().await {
-                    tx_shutdown.send(MainShutdown {}).await?;
+                    tx_shutdown.send(MainShutdown(0)).await?;
                 }
 
                 Ok(())

--- a/tab-command/src/message/main.rs
+++ b/tab-command/src/message/main.rs
@@ -3,8 +3,14 @@ use tab_api::{
     tab::TabId,
 };
 
-#[derive(Debug)]
-pub struct MainShutdown {}
+#[derive(Debug, Clone)]
+pub struct MainShutdown(pub i32);
+
+impl Default for MainShutdown {
+    fn default() -> Self {
+        MainShutdown(0)
+    }
+}
 
 #[derive(Debug, Clone)]
 pub enum MainRecv {

--- a/tab-command/src/service/main/autocomplete_close_tab.rs
+++ b/tab-command/src/service/main/autocomplete_close_tab.rs
@@ -26,7 +26,7 @@ impl Service for MainAutocompleteCloseTabsService {
                         active_tabs.tabs.into_iter().map(|tab| tab.1.name).collect();
                     Self::echo_completion(&tabs);
 
-                    tx_shutdown.send(MainShutdown {}).await.ok();
+                    tx_shutdown.send(MainShutdown(0)).await.ok();
                 }
             }
 

--- a/tab-command/src/service/main/autocomplete_tab.rs
+++ b/tab-command/src/service/main/autocomplete_tab.rs
@@ -25,7 +25,7 @@ impl Service for MainAutocompleteTabsService {
                     let tabs = workspace.tabs.iter().map(|tab| &tab.name).collect();
                     Self::echo_completion(tabs);
 
-                    tx_shutdown.send(MainShutdown {}).await.ok();
+                    tx_shutdown.send(MainShutdown(0)).await.ok();
                 }
             }
 

--- a/tab-command/src/service/main/check_workspace.rs
+++ b/tab-command/src/service/main/check_workspace.rs
@@ -23,7 +23,7 @@ impl Service for MainCheckWorkspaceService {
                     let workspace = await_state(&mut rx_workspace).await?;
 
                     Self::echo_errors(&workspace.errors);
-                    tx_shutdown.send(MainShutdown {}).await.ok();
+                    tx_shutdown.send(MainShutdown(0)).await.ok();
                     break;
                 }
             }

--- a/tab-command/src/service/main/close_tabs.rs
+++ b/tab-command/src/service/main/close_tabs.rs
@@ -27,10 +27,10 @@ impl Service for MainCloseTabsService {
             while let Some(msg) = rx.recv().await {
                 if let MainRecv::CloseTabs(tabs) = msg {
                     let state = await_state(&mut rx_active).await?;
-                    Self::close_tabs(tabs, state, &mut tx_request).await?;
+                    let exit_code = Self::close_tabs(tabs, state, &mut tx_request).await?;
 
                     time::delay_for(Duration::from_millis(5)).await;
-                    tx_shutdown.send(MainShutdown {}).await?;
+                    tx_shutdown.send(MainShutdown(exit_code)).await?;
                     break;
                 }
             }
@@ -47,7 +47,7 @@ impl MainCloseTabsService {
         tabs: Vec<String>,
         state: ActiveTabsState,
         tx_websocket: &mut impl Sender<Request>,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<i32> {
         if tabs.is_empty() {
             if let Ok(tab) = std::env::var("TAB_ID") {
                 eprintln!(
@@ -58,10 +58,11 @@ impl MainCloseTabsService {
                 let id = tab.parse()?;
                 tx_websocket.send(Request::CloseTab(id)).await?;
             } else {
-                eprintln!("No arguments or current tab was detected.");
+                eprintln!("No arguments or current tab were detected.");
+                return Ok(1);
             }
 
-            return Ok(());
+            return Ok(0);
         }
 
         let running_tabs = state.into_name_set();
@@ -80,6 +81,6 @@ impl MainCloseTabsService {
             tx_websocket.send(Request::DisconnectTab(tab.id)).await?;
         }
 
-        Ok(())
+        Ok(0)
     }
 }

--- a/tab-command/src/service/main/global_shutdown.rs
+++ b/tab-command/src/service/main/global_shutdown.rs
@@ -23,7 +23,7 @@ impl Service for MainGlobalShutdownService {
                 if let MainRecv::GlobalShutdown = msg {
                     tx.send(Request::GlobalShutdown).await?;
                     time::delay_for(Duration::from_millis(10)).await;
-                    tx_shutdown.send(MainShutdown {}).await?;
+                    tx_shutdown.send(MainShutdown(0)).await?;
                 }
             }
 

--- a/tab-command/src/service/main/list_tabs.rs
+++ b/tab-command/src/service/main/list_tabs.rs
@@ -28,7 +28,7 @@ impl Service for MainListTabsService {
                     }
 
                     Self::echo_tabs(&workspace.tabs);
-                    tx_shutdown.send(MainShutdown {}).await.ok();
+                    tx_shutdown.send(MainShutdown(0)).await.ok();
                     break;
                 }
             }

--- a/tab-daemon/src/message/daemon.rs
+++ b/tab-daemon/src/message/daemon.rs
@@ -1,3 +1,3 @@
 /// Terminates the daemon process.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct DaemonShutdown;

--- a/tab-pty/src/message/pty.rs
+++ b/tab-pty/src/message/pty.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, path::PathBuf};
 use tab_api::chunk::{InputChunk, OutputChunk};
 
 /// Terminates the process, websocket connection, and via cancellation the connected PTY shell session
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct MainShutdown {}
 
 /// Terminates the PTY process.  Forwarded to the `MainBus` as a `MainShutdown`.

--- a/tab/src/main.rs
+++ b/tab/src/main.rs
@@ -72,6 +72,7 @@ pub fn main() -> anyhow::Result<()> {
 
         Ok(())
     } else {
-        tab_command::command_main(args, TAB_VERSION)
+        let exit_code = tab_command::command_main(args, TAB_VERSION)?;
+        std::process::exit(exit_code);
     }
 }


### PR DESCRIPTION
If `tab --close` or `tab --disconnect` are provided no args, they fall back to closing the current tab.  If no current tab is detected, return exit code 1.