### PR TITLE
Fix several 0.5 bugs and a debug mode timing bug

### DIFF
--- a/common/tab-api/src/config.rs
+++ b/common/tab-api/src/config.rs
@@ -60,6 +60,13 @@ pub fn daemon_log() -> Result<PathBuf> {
     Ok(dir)
 }
 
+/// Returns the path to the pty's logfile.
+pub fn pty_log() -> Result<PathBuf> {
+    let mut dir = data_path()?;
+    dir.push("pty.log");
+    Ok(dir)
+}
+
 /// Returns the path to a unique logfile fro the given shell process, and tab name.
 pub fn history_path(shell: &str, name: &str) -> Result<PathBuf> {
     let mut path = data_path()?;

--- a/common/tab-api/src/launch.rs
+++ b/common/tab-api/src/launch.rs
@@ -7,6 +7,7 @@ use crate::{
     env::is_raw_mode,
     log::get_level_str,
 };
+use anyhow::Context;
 use lifeline::prelude::*;
 use log::*;
 use std::{
@@ -80,7 +81,7 @@ pub async fn launch_daemon() -> anyhow::Result<DaemonConfig> {
 
 /// Launches a new PTY process, which will connect to the running daemon.
 pub fn launch_pty() -> anyhow::Result<()> {
-    let exec = std::env::current_exe()?;
+    let exec = std::env::current_exe().context("failed to get current executable")?;
     debug!("launching `tab-pty` at {}", &exec.to_string_lossy());
 
     let mut child = Command::new(exec);
@@ -98,7 +99,7 @@ pub fn launch_pty() -> anyhow::Result<()> {
 
     crate::env::forward_env(&mut child);
 
-    let _child = child.spawn()?;
+    let _child = child.spawn().context("failed to spawn child process")?;
 
     Ok(())
 }

--- a/tab-command/src/service/terminal/echo_mode.rs
+++ b/tab-command/src/service/terminal/echo_mode.rs
@@ -37,9 +37,8 @@ pub fn reset_cursor() {
             .queue(crossterm::cursor::Show {})
             .expect("failed to queue reset command")
             .queue(crossterm::cursor::DisableBlinking {})
-            .expect("failed to queue reset command")
-            .queue(crossterm::terminal::LeaveAlternateScreen {})
             .expect("failed to queue reset command");
+
         // ansi escape sequence that exits alternate keypad mode
 
         // this is the xterm rmkx value.
@@ -76,12 +75,6 @@ impl Service for TerminalEchoService {
         let _input = Self::try_task("stdin", forward_stdin(tx, tx_terminal, tx_shutdown));
 
         Ok(TerminalEchoService { _input, _output })
-    }
-}
-
-impl Drop for TerminalEchoService {
-    fn drop(&mut self) {
-        disable_raw_mode();
     }
 }
 

--- a/tab-daemon/src/bus/cli.rs
+++ b/tab-daemon/src/bus/cli.rs
@@ -71,7 +71,7 @@ impl CarryFrom<ListenerBus> for CliBus {
 
     fn carry_from(&self, from: &ListenerBus) -> Self::Lifeline {
         let _forward = {
-            let rx_tab = from.rx::<TabSend>()?;
+            let rx_tab = from.rx::<TabSend>()?.log();
 
             let tx_conn = self.tx::<CliRecv>()?;
             let tx_subscription = self.tx::<CliSubscriptionRecv>()?;

--- a/tab-daemon/src/bus/pty.rs
+++ b/tab-daemon/src/bus/pty.rs
@@ -138,7 +138,7 @@ impl CarryFrom<ListenerBus> for PtyBus {
 
         let _to_listener = {
             let rx_id = self.rx::<PtyState>()?.into_inner();
-            let mut rx_pty = self.rx::<PtySend>()?;
+            let mut rx_pty = self.rx::<PtySend>()?.log();
 
             let mut tx_tab = from.tx::<TabSend>()?;
             let mut tx_tab_manager = from.tx::<TabManagerRecv>()?;

--- a/tab-daemon/src/service/cli.rs
+++ b/tab-daemon/src/service/cli.rs
@@ -185,7 +185,7 @@ impl CliService {
         msg: CliRecv,
         tx_websocket: &mut impl Sender<Response>,
     ) -> anyhow::Result<()> {
-        trace!("message from daemon: {:?}", &msg);
+        debug!("message from daemon: {:?}", &msg);
         match msg {
             CliRecv::TabStarted(metadata) => {
                 tx_websocket

--- a/tab-daemon/src/service/daemon/tab_assignment.rs
+++ b/tab-daemon/src/service/daemon/tab_assignment.rs
@@ -79,11 +79,15 @@ impl Service for TabAssignmentService {
                         .unwrap_or(true)
                     {
                         debug!("launching pty process");
-                        launch_pty()?;
+                        if let Err(e) = launch_pty() {
+                            error!("failed to launch initial pty process: {}", e);
+                        }
 
                         while let Ok(_) = rx.inner_mut().try_recv() {
                             debug!("launching pty process");
-                            launch_pty()?;
+                            if let Err(e) = launch_pty() {
+                                error!("failed to launch pty process: {}", e);
+                            }
                         }
 
                         last_spawn = Some(Instant::now());

--- a/tab-daemon/src/service/pty.rs
+++ b/tab-daemon/src/service/pty.rs
@@ -29,7 +29,7 @@ impl Service for PtyService {
         // notify the tab manager of status
 
         let _websocket = {
-            let mut rx_websocket = bus.rx::<PtyWebsocketResponse>()?;
+            let mut rx_websocket = bus.rx::<PtyWebsocketResponse>()?.log();
             let mut tx_daemon = bus.tx::<PtySend>()?;
             let mut tx_shutdown = bus.tx::<PtyShutdown>()?;
 
@@ -37,6 +37,7 @@ impl Service for PtyService {
                 while let Some(msg) = rx_websocket.recv().await {
                     match msg {
                         PtyWebsocketResponse::Started(metadata) => {
+                            info!("PTY process has started on tab {}", metadata.id);
                             tx_daemon.send(PtySend::Started(metadata)).await?;
                         }
                         PtyWebsocketResponse::Output(output) => {


### PR DESCRIPTION
Bugfixes:
- In debug mode, the PTY sometimes failed to initialize because the PtyWebsocketRequest receiver did not catch the Init message.
- In Ubuntu, the alternate screen reset caused bash to repaint over existing text.
- The Fuzzy Finder sometimes failed to clear the screen, as there was no synchronization between the selection event that triggered the repaint, and the output task.  Now the selection task holds the output lifeline, and drops it when sending a selection/termination message.
- There was no PTY log!  Added `pty.log` to the data_dir() tab folder.  Each pty will truncate the log, so this is intended for debugging.