### PR TITLE
Fix a few subtle bugs that caused corruption during interactive editor sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1505,8 +1505,8 @@ dependencies = [
  "snailquote",
  "strip-ansi-escapes",
  "tab-api 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tab-command 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tab-daemon 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tab-command",
+ "tab-daemon",
  "tab-pty 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile",
  "tokio",
@@ -1575,30 +1575,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tab-command"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3907f32c307ad92b0e040adfde98561e98c5c7e8fe5005e477566746bb1cce8e"
-dependencies = [
- "anyhow",
- "clap",
- "crossterm",
- "dirs",
- "fuzzy-matcher",
- "lifeline",
- "log",
- "semver",
- "serde",
- "serde_yaml",
- "simplelog",
- "tab-api 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tab-websocket 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror",
- "tokio",
- "typed-builder",
-]
-
-[[package]]
 name = "tab-daemon"
 version = "0.5.0"
 dependencies = [
@@ -1620,28 +1596,6 @@ dependencies = [
  "tokio-io",
  "tokio-test",
  "tungstenite",
-]
-
-[[package]]
-name = "tab-daemon"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4ac7082bb953bbbe3a4874b3c0047d2e951033016df5f758907a2a6a329e6e"
-dependencies = [
- "anyhow",
- "async-trait",
- "base64 0.13.0",
- "dirs",
- "lifeline",
- "log",
- "rand",
- "serde_yaml",
- "simplelog",
- "tab-api 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tab-websocket 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror",
- "tokio",
- "tokio-io",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,6 @@ members = [
 
 # tab-api = { path = './common/tab-api/' }
 # tab-websocket = { path = './common/tab-websocket/' }
-# tab-command = { path = './tab-command/' }
-# tab-daemon = { path = './tab-daemon/' }
+tab-command = { path = './tab-command/' }
+tab-daemon = { path = './tab-daemon/' }
 # tab-pty = { path = './tab-pty/' }

--- a/tab-command/src/service/terminal/echo_mode.rs
+++ b/tab-command/src/service/terminal/echo_mode.rs
@@ -169,7 +169,7 @@ async fn write_stdout(stdout: &mut Stdout, data: Vec<u8>) -> anyhow::Result<()> 
             let next = data[index];
 
             if next == b'\n' {
-                stdout.write("\r\n".as_bytes()).await?;
+                stdout.write("\n".as_bytes()).await?;
                 index += 1;
             }
         }

--- a/tab-daemon/src/service/pty/scrollback.rs
+++ b/tab-daemon/src/service/pty/scrollback.rs
@@ -8,7 +8,8 @@ use std::{collections::VecDeque, sync::Arc};
 use tab_api::chunk::OutputChunk;
 use tokio::sync::Mutex;
 
-static MIN_CAPACITY: usize = 32768;
+// 128MB memory limit
+static MIN_CAPACITY: usize = 134217728;
 static MAX_CHUNK_LEN: usize = 4096;
 
 /// Spawns with a pty connection, and maintains a scrollback buffer.  Provides scrollback for tab-command clients
@@ -112,11 +113,12 @@ impl ScrollbackBuffer {
                 self.size += chunk.len();
 
                 debug!(
-                    "scrollback appending stdout chunk {}..{} to existing chunk {}..{}",
+                    "scrollback appending stdout chunk {}..{} to existing chunk {}..{}, size {}",
                     chunk.start(),
                     chunk.end(),
                     back.start(),
-                    back.end()
+                    back.end(),
+                    self.size,
                 );
                 back.data.append(&mut chunk.data);
 
@@ -125,9 +127,10 @@ impl ScrollbackBuffer {
         }
 
         debug!(
-            "scrollback pushing new chunk {}..{}",
+            "scrollback pushing new chunk {}..{}, size {}",
             chunk.start(),
-            chunk.end()
+            chunk.end(),
+            self.size + chunk.len()
         );
 
         self.size += chunk.len();


### PR DESCRIPTION
Fix two issues that caused rendering corruption when interactive editors (neovim, kakoune) were used within a tab session.
- Neovim & Kakoune experienced corruption when reconnecting an active session, due to an insufficient MIN_CAPACITY constant in the scrollback buffer.  The new default is 128MB of scrollback which is enough for about 6000 scrolls through the tab README.md file.  In the future, I'm going to look at compressing the scrollback buffer by pruning stdout that has been repainted.
- Kakoune experienced cursor corruption when moving the cursor on the 2nd/3rd/nth column.  This was caused by an incorrect `\n' character being inserted by the tab-command TerminalEchoMode service.

Resolves #226 