### PR TITLE
Remove apple-darwin from release matrix, as it isn't getting any downloads and it's failing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,15 +12,15 @@ jobs:
         target:
           - x86_64-unknown-linux-gnu
           - x86_64-unknown-linux-musl
-          - x86_64-apple-darwin
+          # - x86_64-apple-darwin
           # - x86_64-pc-windows-msvc
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
-          - target: x86_64-apple-darwin
-            os: macOS-latest
+          # - target: x86_64-apple-darwin
+          #   os: macOS-latest
           # - target: x86_64-pc-windows-msvc
           #   os: windows-latest
           #   name: tab-x86_64-pc-windows-msvc.zip
@@ -72,7 +72,7 @@ jobs:
         target:
           - x86_64-unknown-linux-gnu
           - x86_64-unknown-linux-musl
-          - x86_64-apple-darwin
+          # - x86_64-apple-darwin
           # - x86_64-pc-windows-msvc
         include:
           - target: x86_64-unknown-linux-gnu
@@ -81,9 +81,9 @@ jobs:
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
             name: tab-x86_64-unknown-linux-musl.tar.gz
-          - target: x86_64-apple-darwin
-            os: macOS-latest
-            name: tab-x86_64-apple-darwin.tar.gz
+          # - target: x86_64-apple-darwin
+          #   os: macOS-latest
+          #   name: tab-x86_64-apple-darwin.tar.gz
           # - target: x86_64-pc-windows-msvc
           #   os: windows-latest
           #   name: tab-x86_64-pc-windows-msvc.zip


### PR DESCRIPTION
The homebrew job builds a separate OSX binary, and that is getting all the downloads.