### PR TITLE
Fix a resize bug that affected resumed retask sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1505,7 +1505,7 @@ dependencies = [
  "snailquote",
  "strip-ansi-escapes",
  "tab-api 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tab-command 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tab-command",
  "tab-daemon 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tab-pty 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile",
@@ -1571,30 +1571,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-test",
- "typed-builder",
-]
-
-[[package]]
-name = "tab-command"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d86099910d5ca618726ded1c871be1dab7dfed384e630f3ea4cd6296139cac04"
-dependencies = [
- "anyhow",
- "clap",
- "crossterm",
- "dirs",
- "fuzzy-matcher",
- "lifeline",
- "log",
- "semver",
- "serde",
- "serde_yaml",
- "simplelog",
- "tab-api 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tab-websocket 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror",
- "tokio",
  "typed-builder",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,6 @@ members = [
 
 # tab-api = { path = './common/tab-api/' }
 # tab-websocket = { path = './common/tab-websocket/' }
-# tab-command = { path = './tab-command/' }
+tab-command = { path = './tab-command/' }
 # tab-daemon = { path = './tab-daemon/' }
 # tab-pty = { path = './tab-pty/' }

--- a/tab-command/src/bus/tab.rs
+++ b/tab-command/src/bus/tab.rs
@@ -11,7 +11,6 @@ use crate::{
         tab::TabMetadataState,
         tab::{SelectOrRetaskTab, SelectTab, TabState},
         tabs::ActiveTabsState,
-        terminal::TerminalSizeState,
         workspace::WorkspaceState,
     },
 };
@@ -45,10 +44,6 @@ impl Message<TabBus> for TabState {
 }
 
 impl Message<TabBus> for TabMetadataState {
-    type Channel = watch::Sender<Self>;
-}
-
-impl Message<TabBus> for TerminalSizeState {
     type Channel = watch::Sender<Self>;
 }
 

--- a/tab-daemon/src/service/cli.rs
+++ b/tab-daemon/src/service/cli.rs
@@ -157,7 +157,7 @@ impl CliService {
                 tx_daemon.send(message).await.context("tx_daemon closed")?;
             }
             Request::ResizeTab(id, dimensions) => {
-                debug!("resizing tab {} to {:?}", id.0, dimensions);
+                info!("Resizing tab {} to {:?}", id.0, dimensions);
                 tx_daemon.send(CliSend::ResizeTab(id, dimensions)).await?;
             }
             Request::CloseTab(id) => {


### PR DESCRIPTION
TerminalSizeState was carried on the TabBus, but it was not updated.  Removed from the TabBus and replaced with crate::env::terminal_size()