### PR TITLE
adding active indicator

### DIFF
--- a/tab-command/src/service/main/list_tabs.rs
+++ b/tab-command/src/service/main/list_tabs.rs
@@ -61,11 +61,7 @@ impl MainListTabsService {
 
         println!("Available tabs:");
         let cwd: String = env::current_dir()
-            .unwrap_or_else(|_| {
-                let mut path = std::path::PathBuf::new();
-                path.push("/");
-                path
-            })
+            .unwrap_or_default()
             .to_str()
             .unwrap_or_default()
             .to_owned();

--- a/tab-command/src/service/main/list_tabs.rs
+++ b/tab-command/src/service/main/list_tabs.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 use std::env;
 use std::io::{stdout, Write};
+use std::path::PathBuf;
 
 use crossterm::{
     execute,
@@ -60,17 +61,13 @@ impl MainListTabsService {
         let target_len = len + 4;
 
         println!("Available tabs:");
-        let cwd: String = env::current_dir()
-            .unwrap_or_default()
-            .to_str()
-            .unwrap_or_default()
-            .to_owned();
+        let cwd: PathBuf = env::current_dir().unwrap_or_default();
 
         for tab in tabs.iter() {
             let name = &tab.name;
             print!("    ");
 
-            if is_active(tab, &cwd) && *name == get_working_tab() {
+            if *name == get_working_tab() {
                 color_active_tabs(name, Color::Yellow)
             } else if is_active(tab, &cwd) {
                 color_active_tabs(name, Color::Blue)
@@ -90,15 +87,8 @@ impl MainListTabsService {
     }
 }
 
-fn is_active(tab: &WorkspaceTab, cwd: &str) -> bool {
-    let name = &tab.name;
-    if tab.doc == None && *name == get_working_tab() {
-        true
-    } else if tab.doc != None && cwd.contains(&tab.directory.display().to_string()) {
-        true
-    } else {
-        false
-    }
+fn is_active(tab: &WorkspaceTab, cwd: &PathBuf) -> bool {
+    cwd.starts_with(tab.directory.as_path())
 }
 
 fn color_active_tabs(name: &str, color: Color) {

--- a/tab-command/src/service/main/list_tabs.rs
+++ b/tab-command/src/service/main/list_tabs.rs
@@ -2,6 +2,13 @@ use crate::{
     message::main::MainRecv, message::main::MainShutdown, prelude::*,
     state::workspace::WorkspaceState, state::workspace::WorkspaceTab, utils::await_state,
 };
+use std::env;
+use std::io::{stdout, Write};
+
+use crossterm::{
+    execute,
+    style::{Color, Print, ResetColor, SetForegroundColor},
+};
 
 pub struct MainListTabsService {
     _run: Lifeline,
@@ -53,10 +60,27 @@ impl MainListTabsService {
         let target_len = len + 4;
 
         println!("Available tabs:");
+        let cwd: String = env::current_dir()
+            .unwrap_or_else(|_| {
+                let mut path = std::path::PathBuf::new();
+                path.push("/");
+                path
+            })
+            .to_str()
+            .unwrap_or_default()
+            .to_owned();
 
         for tab in tabs.iter() {
             let name = &tab.name;
-            print!("    {}", name);
+            print!("    ");
+
+            if is_active(tab, &cwd) && *name == get_working_tab() {
+                color_active_tabs(name, Color::Yellow)
+            } else if is_active(tab, &cwd) {
+                color_active_tabs(name, Color::Blue)
+            } else {
+                print!("{}", name);
+            }
 
             if let Some(ref doc) = tab.doc {
                 for _ in name.len()..target_len {
@@ -68,4 +92,27 @@ impl MainListTabsService {
             }
         }
     }
+}
+
+fn is_active(tab: &WorkspaceTab, cwd: &str) -> bool {
+    let name = &tab.name;
+    if tab.doc == None && *name == get_working_tab() {
+        true
+    } else if tab.doc != None && cwd.contains(&tab.directory.display().to_string()) {
+        true
+    } else {
+        false
+    }
+}
+
+fn color_active_tabs(name: &str, color: Color) {
+    execute!(stdout(), SetForegroundColor(color), Print(name), ResetColor).ok();
+}
+
+fn get_working_tab() -> String {
+    env::var_os("TAB")
+        .unwrap_or_default()
+        .to_str()
+        .unwrap_or_default()
+        .to_string()
 }


### PR DESCRIPTION
I am not 100% sure this is the intended behaviour of #51, but here is how I envisioned it based on the description.

`tab -l`
![image](https://user-images.githubusercontent.com/17597548/100165784-5a3f8e80-2e78-11eb-9e26-5e9058ada933.png)

`tab foo`
![image](https://user-images.githubusercontent.com/17597548/100165812-704d4f00-2e78-11eb-84a4-070173decd97.png)

`tab tab-rs`
![image](https://user-images.githubusercontent.com/17597548/100165839-7f340180-2e78-11eb-8922-95b62a035623.png)
