### PR TITLE
Fix a bug where the daemon pidfile refers to a process which is running, but isn't the daemon.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1504,7 +1504,7 @@ dependencies = [
  "simplelog",
  "snailquote",
  "strip-ansi-escapes",
- "tab-api 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tab-api",
  "tab-command",
  "tab-daemon",
  "tab-pty 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1518,24 +1518,6 @@ dependencies = [
 [[package]]
 name = "tab-api"
 version = "0.5.0"
-dependencies = [
- "anyhow",
- "dirs",
- "lifeline",
- "log",
- "serde",
- "serde_yaml",
- "snailquote",
- "sysinfo",
- "thiserror",
- "tokio",
-]
-
-[[package]]
-name = "tab-api"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec2fef6a617d860ea90652287bff9f14442ead7d6682b29a9aef03ae7851d7d4"
 dependencies = [
  "anyhow",
  "dirs",
@@ -1566,7 +1548,7 @@ dependencies = [
  "serde",
  "serde_yaml",
  "simplelog",
- "tab-api 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tab-api",
  "tab-websocket 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
  "tokio",
@@ -1589,7 +1571,7 @@ dependencies = [
  "rand",
  "serde_yaml",
  "simplelog",
- "tab-api 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tab-api",
  "tab-websocket 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
  "tokio",
@@ -1613,7 +1595,7 @@ dependencies = [
  "rand",
  "serde_yaml",
  "simplelog",
- "tab-api 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tab-api",
  "tab-pty-process 0.2.0",
  "tab-websocket 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
@@ -1638,7 +1620,7 @@ dependencies = [
  "rand",
  "serde_yaml",
  "simplelog",
- "tab-api 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tab-api",
  "tab-pty-process 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tab-websocket 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 # Uncomment and commit when you make changes to a local crate
 # These will be replaced with published crates.io versions during the release process
 
-# tab-api = { path = './common/tab-api/' }
+tab-api = { path = './common/tab-api/' }
 # tab-websocket = { path = './common/tab-websocket/' }
 tab-command = { path = './tab-command/' }
 tab-daemon = { path = './tab-daemon/' }


### PR DESCRIPTION
The issue here was that across reboots, the daemon pidfile could refer to a new process - not the daemon!  In that case, tab wouldn't clear the pidfile and relaunch the daemon.

This PR introduces logic to check that `--_launch daemon` is in the command string provided by sysinfo.

I did not check that `tab` is in the command, as tab could be installed as any executable name.