### PR TITLE
Link-time Optimization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,6 @@ members = [
 # tab-command = { path = './tab-command/' }
 # tab-daemon = { path = './tab-daemon/' }
 # tab-pty = { path = './tab-pty/' }
+
+[profile.release]
+lto = true


### PR DESCRIPTION
This reduces release-mode binary size from 15.7mb to 11mb.

A further manual call to `strip` reduces the binary to 8.4mb, and hopefully the `cargo` patch to run `strip` automatically will be included soon.
