### PR TITLE
Reduce CPU consumption and fix a rendering corruption issue with kakoune relative line numbers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1506,8 +1506,8 @@ dependencies = [
  "strip-ansi-escapes",
  "tab-api 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tab-command 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tab-daemon 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tab-pty 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tab-daemon",
+ "tab-pty",
  "tempfile",
  "tokio",
  "tokio-test",
@@ -1623,28 +1623,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tab-daemon"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca5b3fd8c6bd016a40033272051dd9a0c83e5fca7d7b142962c859b0a81339fb"
-dependencies = [
- "anyhow",
- "async-trait",
- "base64 0.13.0",
- "dirs",
- "lifeline",
- "log",
- "rand",
- "serde_yaml",
- "simplelog",
- "tab-api 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tab-websocket 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror",
- "tokio",
- "tokio-io",
-]
-
-[[package]]
 name = "tab-pty"
 version = "0.5.2"
 dependencies = [
@@ -1660,32 +1638,7 @@ dependencies = [
  "serde_yaml",
  "simplelog",
  "tab-api 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tab-pty-process 0.2.0",
- "tab-websocket 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror",
- "tokio",
- "tokio-io",
-]
-
-[[package]]
-name = "tab-pty"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a11f82700e994d78969ad3b7b62ba48f9ec800475dea7896ceea21ff962358f0"
-dependencies = [
- "anyhow",
- "async-trait",
- "base64 0.12.3",
- "bincode",
- "dirs",
- "futures 0.3.6",
- "lifeline",
- "log",
- "rand",
- "serde_yaml",
- "simplelog",
- "tab-api 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tab-pty-process 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tab-pty-process",
  "tab-websocket 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
  "tokio",
@@ -1699,20 +1652,6 @@ dependencies = [
  "async-trait",
  "bytes 0.4.12",
  "errno",
- "futures 0.3.6",
- "libc",
- "mio 0.6.22",
- "tokio",
-]
-
-[[package]]
-name = "tab-pty-process"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4b92455283e9992144259f518c09f80f15493329d0a3dc6700d15bd3547ab2d"
-dependencies = [
- "async-trait",
- "bytes 0.4.12",
  "futures 0.3.6",
  "libc",
  "mio 0.6.22",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1505,7 +1505,7 @@ dependencies = [
  "snailquote",
  "strip-ansi-escapes",
  "tab-api 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tab-command 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tab-command",
  "tab-daemon",
  "tab-pty",
  "tempfile",
@@ -1571,30 +1571,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-test",
- "typed-builder",
-]
-
-[[package]]
-name = "tab-command"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea1e24e552bb3a10bb12c0d9659de3285a47b1ed744c85af1f3aedd13b8b255f"
-dependencies = [
- "anyhow",
- "clap",
- "crossterm",
- "dirs",
- "fuzzy-matcher",
- "lifeline",
- "log",
- "semver",
- "serde",
- "serde_yaml",
- "simplelog",
- "tab-api 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tab-websocket 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror",
- "tokio",
  "typed-builder",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,5 @@ members = [
 # tab-api = { path = './common/tab-api/' }
 # tab-websocket = { path = './common/tab-websocket/' }
 # tab-command = { path = './tab-command/' }
-# tab-daemon = { path = './tab-daemon/' }
-# tab-pty = { path = './tab-pty/' }
+tab-daemon = { path = './tab-daemon/' }
+tab-pty = { path = './tab-pty/' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,6 @@ members = [
 
 # tab-api = { path = './common/tab-api/' }
 # tab-websocket = { path = './common/tab-websocket/' }
-# tab-command = { path = './tab-command/' }
+tab-command = { path = './tab-command/' }
 tab-daemon = { path = './tab-daemon/' }
 tab-pty = { path = './tab-pty/' }

--- a/tab-command/src/service/terminal/echo_mode.rs
+++ b/tab-command/src/service/terminal/echo_mode.rs
@@ -1,6 +1,7 @@
 use std::{
     io::Write,
     sync::atomic::{AtomicBool, Ordering},
+    time::Duration,
 };
 
 use crate::message::terminal::{TerminalInput, TerminalOutput, TerminalShutdown};
@@ -8,7 +9,10 @@ use crate::{message::terminal::TerminalSend, prelude::*};
 use anyhow::Context;
 use crossterm::QueueableCommand;
 use tab_api::env::is_raw_mode;
-use tokio::io::{AsyncReadExt, AsyncWriteExt, Stdout};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt, Stdout},
+    time,
+};
 
 use super::echo_input::{key_bindings, Action, InputFilter, KeyBindings};
 
@@ -127,6 +131,8 @@ async fn forward_stdin(
 
             break;
         }
+
+        time::delay_for(Duration::from_micros(150)).await;
     }
 
     Ok(())

--- a/tab-daemon/src/service/daemon/listener.rs
+++ b/tab-daemon/src/service/daemon/listener.rs
@@ -12,6 +12,7 @@ use crate::{
 use crate::{prelude::*, service::cli::subscription::CliSubscriptionService};
 
 use lifeline::dyn_bus::DynBus;
+use tab_api::pty::PtyWebsocketRequest;
 use tab_websocket::{
     bus::{WebsocketCarrier, WebsocketListenerBus},
     message::listener::WebsocketConnectionMessage,
@@ -120,6 +121,8 @@ impl ListenerService {
                     let pty_bus = PtyBus::default();
                     pty_bus.capacity::<PtySend>(128)?;
                     pty_bus.capacity::<PtyRecv>(128)?;
+                    pty_bus.capacity::<PtyWebsocketRequest>(2048);
+                    pty_bus.capacity::<PtyWebsocketResponse>(2048);
 
                     let _listener_carrier = pty_bus.carry_from(&bus)?;
                     let _websocket_carrier = pty_bus.carry_into(&msg.bus)?;

--- a/tab-daemon/src/service/daemon/listener.rs
+++ b/tab-daemon/src/service/daemon/listener.rs
@@ -121,8 +121,8 @@ impl ListenerService {
                     let pty_bus = PtyBus::default();
                     pty_bus.capacity::<PtySend>(128)?;
                     pty_bus.capacity::<PtyRecv>(128)?;
-                    pty_bus.capacity::<PtyWebsocketRequest>(2048);
-                    pty_bus.capacity::<PtyWebsocketResponse>(2048);
+                    pty_bus.capacity::<PtyWebsocketRequest>(128)?;
+                    pty_bus.capacity::<PtyWebsocketResponse>(128)?;
 
                     let _listener_carrier = pty_bus.carry_from(&bus)?;
                     let _websocket_carrier = pty_bus.carry_into(&msg.bus)?;

--- a/tab-daemon/src/service/daemon/listener.rs
+++ b/tab-daemon/src/service/daemon/listener.rs
@@ -12,7 +12,7 @@ use crate::{
 use crate::{prelude::*, service::cli::subscription::CliSubscriptionService};
 
 use lifeline::dyn_bus::DynBus;
-use tab_api::pty::PtyWebsocketRequest;
+use tab_api::pty::{PtyWebsocketRequest, PtyWebsocketResponse};
 use tab_websocket::{
     bus::{WebsocketCarrier, WebsocketListenerBus},
     message::listener::WebsocketConnectionMessage,

--- a/tab-pty/src/service/pty.rs
+++ b/tab-pty/src/service/pty.rs
@@ -2,7 +2,10 @@ use crate::message::pty::{PtyOptions, PtyOutputBarrier, PtyRequest, PtyResponse,
 use crate::prelude::*;
 
 use lifeline::{barrier::*, Receiver, Sender};
-use std::process::{Command, Stdio};
+use std::{
+    process::{Command, Stdio},
+    time::Duration,
+};
 use tab_api::{
     chunk::{InputChunk, OutputChunk},
     env::forward_env_std,
@@ -11,9 +14,12 @@ use tab_pty_process::CommandExt;
 use tab_pty_process::{
     AsyncPtyMaster, AsyncPtyMasterReadHalf, AsyncPtyMasterWriteHalf, Child, PtyMaster,
 };
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    time,
+};
 
-static CHUNK_LEN: usize = 2048;
+static CHUNK_LEN: usize = 4096;
 static OUTPUT_CHANNEL_SIZE: usize = 32;
 static STDIN_CHANNEL_SIZE: usize = 256;
 
@@ -132,6 +138,8 @@ impl PtyService {
 
             tx.send(response).await.ok();
             index += read;
+
+            time::delay_for(Duration::from_micros(500)).await;
         }
     }
 

--- a/tab-pty/src/service/pty.rs
+++ b/tab-pty/src/service/pty.rs
@@ -139,7 +139,7 @@ impl PtyService {
             tx.send(response).await.ok();
             index += read;
 
-            time::delay_for(Duration::from_micros(500)).await;
+            time::delay_for(Duration::from_micros(150)).await;
         }
     }
 


### PR DESCRIPTION
Changes:
- Limit the stdout max packet rate to 0.15ms
- Increase the PtyWebsocketResponse buffer size in the daemon to 128 packets.

Impact:
- Reduces CPU usage when using interactive apps that generate high frequency update events
- Fixes a rendering corruption issue (#268) when kakoune is used with relative line numbers (`add-highlighter global/ number-lines -relative` in kakrc).  