### PR TITLE
Create new tabs in the fuzzy finder!

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ tab-command = { path = './tab-command/' }
 # tab-pty = { path = './tab-pty/' }
 
 [profile.dev]
-opt-level = 3
 
 [profile.release]
 lto = true

--- a/tab-command/src/message/fuzzy.rs
+++ b/tab-command/src/message/fuzzy.rs
@@ -4,6 +4,8 @@ pub enum FuzzyEvent {
     MoveRight,
     MoveUp,
     MoveDown,
+    MoveFirst,
+    MoveLast,
     Insert(char),
     Delete,
     Enter,

--- a/tab-command/src/service/terminal/fuzzy.rs
+++ b/tab-command/src/service/terminal/fuzzy.rs
@@ -193,8 +193,12 @@ impl FuzzyFinderService {
                         }
                         KeyCode::Home => {}
                         KeyCode::End => {}
-                        KeyCode::PageUp => {}
-                        KeyCode::PageDown => {}
+                        KeyCode::PageUp => {
+                            tx_event.send(FuzzyEvent::MoveFirst).await?;
+                        }
+                        KeyCode::PageDown => {
+                            tx_event.send(FuzzyEvent::MoveLast).await?;
+                        }
                         KeyCode::Tab => {
                             tx_event.send(FuzzyEvent::MoveDown).await?;
                         }
@@ -380,6 +384,14 @@ impl FuzzyFinderService {
                     }
                     FuzzyEvent::MoveDown => {
                         index += 1;
+                    }
+                    FuzzyEvent::MoveFirst => {
+                        index = 0;
+                    }
+                    FuzzyEvent::MoveLast => {
+                        if matches.len() > 0 {
+                            index = matches.len() - 1;
+                        }
                     }
                     FuzzyEvent::Resize(_rows, cols) => {
                         terminal_height = cols as usize;

--- a/tab-command/src/service/terminal/fuzzy.rs
+++ b/tab-command/src/service/terminal/fuzzy.rs
@@ -269,14 +269,17 @@ impl FuzzyFinderService {
             .map(|event| FilterEvent::Tabs(event))
             .merge(rx_query.map(|event| FilterEvent::Query(event)));
 
-        let mut entries = TabEntry::build(&Vec::with_capacity(0));
+        let (mut entries, mut prefix_len) = TabEntry::build(&Vec::with_capacity(0));
         let mut query = "".to_string();
+        let mut create_tab_entry = None;
 
         while let Some(event) = rx.next().await {
             match event {
                 FilterEvent::Tabs(state) => {
                     if let Some(ref tabs) = state {
-                        entries = TabEntry::build(&tabs.tabs);
+                        let new_entries = TabEntry::build(&tabs.tabs);
+                        entries = new_entries.0;
+                        prefix_len = new_entries.1;
                     }
                 }
                 FilterEvent::Query(state) => {
@@ -285,6 +288,10 @@ impl FuzzyFinderService {
                     }
 
                     query = state.query;
+                    create_tab_entry = Some(Arc::new(TabEntry::create_tab_entry(
+                        query.as_str(),
+                        prefix_len,
+                    )));
                 }
             }
 
@@ -307,6 +314,7 @@ impl FuzzyFinderService {
             }
 
             let mut matches = Vec::new();
+
             for entry in entries.iter() {
                 // TODO: save lowercase strings for performance?
                 let fuzzy_match = matcher.fuzzy_indices(entry.display.as_str(), query.as_str());
@@ -323,6 +331,16 @@ impl FuzzyFinderService {
             }
 
             matches.sort_by_key(|elem| -elem.score);
+
+            if let Some(ref create) = create_tab_entry {
+                if let None = entries.iter().find(|cmp| cmp.name == create.name) {
+                    matches.push(FuzzyMatch {
+                        score: 0i64,
+                        indices: vec![],
+                        tab: Arc::clone(create),
+                    });
+                }
+            }
 
             tx.send(FuzzyMatchState {
                 matches,

--- a/tab-command/src/state/fuzzy.rs
+++ b/tab-command/src/state/fuzzy.rs
@@ -55,7 +55,8 @@ pub struct FuzzySelectState {
 #[derive(Debug, Clone)]
 pub struct FuzzyMatch {
     pub score: i64,
-    pub indices: Vec<usize>,
+    pub name_indices: Vec<usize>,
+    pub doc_indices: Vec<usize>,
     pub tab: Arc<TabEntry>,
 }
 
@@ -69,61 +70,67 @@ pub struct FuzzyOutputEvent {
 
 #[derive(Debug, Clone)]
 pub struct FuzzyOutputMatch {
-    pub tokens: Vec<Token>,
+    pub name: Vec<Token>,
+    pub doc: Option<Vec<Token>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct FuzzyEntryState {
+    pub entries: Vec<Arc<TabEntry>>,
 }
 
 #[derive(Debug, Clone)]
 pub struct TabEntry {
     pub name: String,
     pub doc: Option<String>,
-    pub display: String,
+    pub sticky: bool,
+}
+
+impl From<&WorkspaceTab> for TabEntry {
+    fn from(tab: &WorkspaceTab) -> Self {
+        Self {
+            name: tab.name.clone(),
+            doc: tab.doc.clone().map(|mut doc| {
+                doc.insert(0, '(');
+                doc.push(')');
+                doc
+            }),
+            sticky: false,
+        }
+    }
 }
 
 impl TabEntry {
-    pub fn build(tabs: &Vec<WorkspaceTab>) -> (Vec<Arc<Self>>, usize) {
-        let mut entries = Vec::with_capacity(tabs.len());
-        let prefix_len = Self::tab_len(&tabs);
-
-        for tab in tabs {
-            let display = Self::display(
-                tab.name.as_str(),
-                tab.doc.as_ref().map(String::as_str),
-                prefix_len,
-            );
-
-            let tab = Self {
-                name: tab.name.clone(),
-                doc: tab.doc.clone(),
-                display,
-            };
-
-            entries.push(Arc::new(tab));
-        }
-
-        (entries, prefix_len)
-    }
-
-    pub fn create_tab_entry(query: &str, prefix_len: usize) -> TabEntry {
+    pub fn entry_new(query: &str) -> TabEntry {
         let name = normalize_name(query);
-        let doc = "new tab";
-
-        let display = Self::display(name.as_str(), Some(doc), prefix_len);
+        let doc = "(new tab)";
 
         TabEntry {
             name,
             doc: Some(doc.to_string()),
-            display,
+            sticky: true,
         }
     }
 
-    fn display(name: &str, doc: Option<&str>, prefix_len: usize) -> String {
-        let mut display = name.to_string();
+    pub fn entry_tutorial() -> TabEntry {
+        let name = "tab/";
+        let doc = "(write a tab name to get started, or press enter to use this one)";
 
-        while display.len() < prefix_len {
+        TabEntry {
+            name: name.to_string(),
+            doc: Some(doc.to_string()),
+            sticky: true,
+        }
+    }
+
+    pub fn display(&self, doc_index: usize) -> String {
+        let mut display = self.name.to_string();
+
+        while display.len() < doc_index {
             display += " ";
         }
 
-        if let Some(ref doc) = doc {
+        if let Some(ref doc) = self.doc {
             display += "(";
             display += doc;
             display += ")";
@@ -132,20 +139,14 @@ impl TabEntry {
         display
     }
 
-    fn tab_len(tabs: &Vec<WorkspaceTab>) -> usize {
-        let max_len = tabs
-            .iter()
-            .map(|tab| tab.name.len())
-            .max()
-            .map(|len| len + 2);
+    pub fn tab_len<'a>(tabs: impl Iterator<Item = &'a Self>) -> usize {
+        let max_len = tabs.map(|tab| tab.name.len()).max().map(|len| len + 2);
         max_len.unwrap_or(0)
     }
 }
 
 #[derive(Debug, Clone)]
 pub enum Token {
-    UnmatchedTab(String),
-    MatchedTab(String),
     Unmatched(String),
     Matched(String),
 }
@@ -158,14 +159,6 @@ pub enum TokenJoin {
 impl Token {
     pub fn join(self, other: Token) -> TokenJoin {
         match (self, other) {
-            (Token::UnmatchedTab(mut a), Token::UnmatchedTab(b)) => {
-                a += b.as_str();
-                TokenJoin::Same(Token::UnmatchedTab(a))
-            }
-            (Token::MatchedTab(mut a), Token::MatchedTab(b)) => {
-                a += b.as_str();
-                TokenJoin::Same(Token::MatchedTab(a))
-            }
             (Token::Unmatched(mut a), Token::Unmatched(b)) => {
                 a += b.as_str();
                 TokenJoin::Same(Token::Unmatched(a))

--- a/tab-command/src/state/fuzzy.rs
+++ b/tab-command/src/state/fuzzy.rs
@@ -105,7 +105,7 @@ impl TabEntry {
 
     pub fn create_tab_entry(query: &str, prefix_len: usize) -> TabEntry {
         let name = normalize_name(query);
-        let doc = "create tab";
+        let doc = "new tab";
 
         let display = Self::display(name.as_str(), Some(doc), prefix_len);
 


### PR DESCRIPTION
Add a `(new tab)` option to the fuzzy finder, that is presented if:
- The user has entered a query that does not conflict with an existing tab.
- The user has no tab entries (e.g. no YAML configs and no running tabs).

Refactor tab name/doc matching.  Some of the name/doc code has been made more generic, and doc indentation happens later in the pipeline.

TabEntry now has a `sticky` property.  Sticky entries are always matched, and have the entire tab name underlined.  Sticky entries are sorted to the end of the list.

Also add bindings for PageUp/PageDown.