### PR TITLE
Refactor terminal resets

### DIFF
--- a/tab-command/src/lib.rs
+++ b/tab-command/src/lib.rs
@@ -2,7 +2,7 @@ use clap::ArgMatches;
 use semver::Version;
 
 use crate::prelude::*;
-use service::{main::*, terminal::disable_raw_mode, terminal::reset_cursor};
+use service::{main::*, terminal::disable_raw_mode, terminal::reset_terminal_state};
 
 use simplelog::{TermLogger, TerminalMode};
 
@@ -103,7 +103,7 @@ async fn main_async(matches: ArgMatches<'_>, tab_version: &'static str) -> anyho
 
     let exit = wait_for_shutdown(rx_shutdown).await;
     disable_raw_mode();
-    reset_cursor();
+    reset_terminal_state();
 
     Ok(exit.0)
 }

--- a/tab-command/src/service/terminal.rs
+++ b/tab-command/src/service/terminal.rs
@@ -17,7 +17,7 @@ mod fuzzy;
 mod terminal_event;
 
 pub use echo_mode::disable_raw_mode;
-pub use echo_mode::reset_cursor;
+pub use echo_mode::reset_terminal_state;
 
 use self::fuzzy::FuzzyFinderService;
 

--- a/tab-command/src/service/terminal/echo_mode.rs
+++ b/tab-command/src/service/terminal/echo_mode.rs
@@ -7,7 +7,6 @@ use std::{
 use crate::message::terminal::{TerminalInput, TerminalOutput, TerminalShutdown};
 use crate::{message::terminal::TerminalSend, prelude::*};
 use anyhow::Context;
-use crossterm::QueueableCommand;
 use tab_api::env::is_raw_mode;
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt, Stdout},
@@ -18,10 +17,10 @@ use super::echo_input::{key_bindings, Action, InputFilter, KeyBindings};
 
 static RESET_ENABLED: AtomicBool = AtomicBool::new(false);
 
-pub fn enable_raw_mode(reset: bool) {
+pub fn enable_raw_mode(reset_enabled: bool) {
     if is_raw_mode() {
         crossterm::terminal::enable_raw_mode().expect("failed to enable raw mode");
-        if reset {
+        if reset_enabled {
             RESET_ENABLED.store(true, Ordering::SeqCst);
             debug!("raw mode enabled");
         }

--- a/tab-command/src/service/terminal/fuzzy.rs
+++ b/tab-command/src/service/terminal/fuzzy.rs
@@ -22,7 +22,7 @@ use fuzzy_matcher::{skim::SkimMatcherV2, FuzzyMatcher};
 use tab_api::tab::normalize_name;
 use tokio::{stream::Stream, stream::StreamExt, sync::watch};
 
-use super::{echo_mode::enable_raw_mode, reset_cursor};
+use super::{echo_mode::enable_raw_mode, reset_terminal_state};
 
 /// Rows reserved by the UI for non-match items
 const RESERVED_ROWS: usize = 2;
@@ -570,8 +570,7 @@ impl FuzzyFinderService {
     }
 
     async fn output(mut rx: impl Receiver<FuzzyOutputEvent>) -> anyhow::Result<()> {
-        enable_raw_mode();
-        reset_cursor();
+        enable_raw_mode(false);
 
         let mut stdout = std::io::stdout();
 

--- a/tab-command/src/service/terminal/fuzzy.rs
+++ b/tab-command/src/service/terminal/fuzzy.rs
@@ -22,7 +22,7 @@ use fuzzy_matcher::{skim::SkimMatcherV2, FuzzyMatcher};
 use tab_api::tab::normalize_name;
 use tokio::{stream::Stream, stream::StreamExt, sync::watch};
 
-use super::{echo_mode::enable_raw_mode, reset_terminal_state};
+use super::echo_mode::enable_raw_mode;
 
 /// Rows reserved by the UI for non-match items
 const RESERVED_ROWS: usize = 2;


### PR DESCRIPTION
There have been several recent bug reports that relate to incorrect terminal state resets when the tab client is disconnected.  Resets on disconnects are necessary, because I allow TUI apps to set any state they want in the connected terminal emulator.

I preferred only resetting the state that was necessary, but I think a full reset is needed due to recent bug reports.