### PR TITLE
More improvements to terminal resets

### DIFF
--- a/tab-command/src/lib.rs
+++ b/tab-command/src/lib.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use clap::ArgMatches;
 use semver::Version;
 
@@ -42,7 +44,7 @@ pub fn command_main(args: ArgMatches, tab_version: &'static str) -> anyhow::Resu
 
     let result = runtime.block_on(async { main_async(args, tab_version).await });
 
-    runtime.shutdown_background();
+    runtime.shutdown_timeout(Duration::from_millis(25));
 
     let code = result?;
 

--- a/tab-command/src/service/main/select_tab.rs
+++ b/tab-command/src/service/main/select_tab.rs
@@ -57,7 +57,7 @@ impl MainSelectTabService {
         info!("selecting tab: {}", name);
 
         tx_terminal
-            .send(TerminalRecv::Mode(TerminalMode::Echo))
+            .send(TerminalRecv::Mode(TerminalMode::Echo(name.clone())))
             .await?;
 
         let message = TabRecv::SelectNamedTab { name, env_tab };

--- a/tab-command/src/service/terminal/echo_mode.rs
+++ b/tab-command/src/service/terminal/echo_mode.rs
@@ -36,9 +36,10 @@ pub fn reset_terminal_state() {
     if is_raw_mode() && RESET_ENABLED.load(Ordering::SeqCst) {
         let mut stdout = std::io::stdout();
 
-        // fully reset the terminal state ESC c
+        // fully reset the terminal state: ESC c
+        // then clear the terminal: ESC [ 2 J
         stdout
-            .write("\x1bc".as_bytes())
+            .write("\x1bc\x1b[2J".as_bytes())
             .expect("failed to queue reset command");
 
         stdout.flush().expect("failed to flush reset commands");

--- a/tab-command/src/service/terminal/echo_mode.rs
+++ b/tab-command/src/service/terminal/echo_mode.rs
@@ -46,7 +46,7 @@ pub fn reset_terminal_state() {
 
         RESET_ENABLED.store(false, Ordering::SeqCst);
 
-        debug!("cursor enabled");
+        debug!("terminal state reset");
     }
 }
 

--- a/tab-command/src/service/terminal/fuzzy.rs
+++ b/tab-command/src/service/terminal/fuzzy.rs
@@ -22,7 +22,7 @@ use fuzzy_matcher::{skim::SkimMatcherV2, FuzzyMatcher};
 use tab_api::tab::normalize_name;
 use tokio::{stream::Stream, stream::StreamExt, sync::watch};
 
-use super::echo_mode::enable_raw_mode;
+use super::echo_mode::{enable_raw_mode, reset_terminal_state};
 
 /// Rows reserved by the UI for non-match items
 const RESERVED_ROWS: usize = 2;
@@ -571,6 +571,7 @@ impl FuzzyFinderService {
 
     async fn output(mut rx: impl Receiver<FuzzyOutputEvent>) -> anyhow::Result<()> {
         enable_raw_mode(false);
+        reset_terminal_state();
 
         let mut stdout = std::io::stdout();
 

--- a/tab-command/src/state/terminal.rs
+++ b/tab-command/src/state/terminal.rs
@@ -18,7 +18,7 @@ pub enum TerminalMode {
     /// No terminal program is active
     None,
     /// Terminal is in raw mode, capturing stdin, and forwarding raw stdout
-    Echo,
+    Echo(String),
     /// Terminal is in interactive finder mode, using Crossterm.
     FuzzyFinder,
 }

--- a/tab-command/src/state/terminal.rs
+++ b/tab-command/src/state/terminal.rs
@@ -17,7 +17,7 @@ impl Default for TerminalSizeState {
 pub enum TerminalMode {
     /// No terminal program is active
     None,
-    /// Terminal is in raw mode, capturing stdin, and forwarding raw stdout
+    /// Terminal is in raw mode, capturing stdin, and forwarding raw stdout (for the given tab name)
     Echo(String),
     /// Terminal is in interactive finder mode, using Crossterm.
     FuzzyFinder,


### PR DESCRIPTION
- More consistently apply terminal resets when switching tabs, or opening the fuzzy finder.  The TerminalService now executes resets if EchoMode has been activated.  And resets when switching tabs.
- Change the reset sequence to `ESC c ESC [ 2 J` - reset then clear.  The clear is needed for the prompt to show up.
- Sometimes the tab-command client didn't shut down due to `shutdown_background` never returning.