### PR TITLE
Improve terminal state management.  Only restart services if mode discriminant changes

### DIFF
--- a/tab-command/src/service/main/select_tab.rs
+++ b/tab-command/src/service/main/select_tab.rs
@@ -1,10 +1,7 @@
 use tab_api::tab::{normalize_name, TabId};
 
 use crate::message::tabs::TabRecv;
-use crate::{
-    message::main::MainRecv, message::terminal::TerminalRecv, prelude::*,
-    state::terminal::TerminalMode,
-};
+use crate::{message::main::MainRecv, prelude::*};
 
 pub fn env_tab_id() -> Option<TabId> {
     if let Ok(id) = std::env::var("TAB_ID") {
@@ -28,12 +25,11 @@ impl Service for MainSelectTabService {
         let mut rx = bus.rx::<MainRecv>()?;
 
         let mut tx_tab = bus.tx::<TabRecv>()?;
-        let mut tx_terminal = bus.tx::<TerminalRecv>()?;
 
         let _run = Self::try_task("run", async move {
             while let Some(recv) = rx.recv().await {
                 if let MainRecv::SelectTab(name) = recv {
-                    Self::select_tab(name, &mut tx_tab, &mut tx_terminal).await?;
+                    Self::select_tab(name, &mut tx_tab).await?;
                 }
             }
 
@@ -45,20 +41,12 @@ impl Service for MainSelectTabService {
 }
 
 impl MainSelectTabService {
-    async fn select_tab(
-        name: String,
-        tx_tab: &mut impl Sender<TabRecv>,
-        tx_terminal: &mut impl Sender<TerminalRecv>,
-    ) -> anyhow::Result<()> {
+    async fn select_tab(name: String, tx_tab: &mut impl Sender<TabRecv>) -> anyhow::Result<()> {
         info!("MainRecv::SelectTab({}) running", &name);
         let name = normalize_name(name.as_str());
         let env_tab = env_tab_id();
 
         info!("selecting tab: {}", name);
-
-        tx_terminal
-            .send(TerminalRecv::Mode(TerminalMode::Echo(name.clone())))
-            .await?;
 
         let message = TabRecv::SelectNamedTab { name, env_tab };
         tx_tab.send(message).await?;

--- a/tab-command/src/service/terminal.rs
+++ b/tab-command/src/service/terminal.rs
@@ -1,3 +1,9 @@
+use std::{
+    io::Write,
+    mem::discriminant,
+    sync::atomic::{AtomicBool, Ordering},
+};
+
 use crate::state::terminal::TerminalMode;
 
 use crate::bus::MainBus;
@@ -9,6 +15,7 @@ use crate::{
 };
 
 use echo_mode::TerminalEchoService;
+use tab_api::env::is_raw_mode;
 use terminal_event::TerminalEventService;
 
 mod echo_input;
@@ -16,10 +23,42 @@ mod echo_mode;
 mod fuzzy;
 mod terminal_event;
 
-pub use echo_mode::disable_raw_mode;
-pub use echo_mode::reset_terminal_state;
-
 use self::fuzzy::FuzzyFinderService;
+
+static RESET_ENABLED: AtomicBool = AtomicBool::new(false);
+
+pub fn enable_raw_mode(reset_enabled: bool) {
+    if is_raw_mode() {
+        crossterm::terminal::enable_raw_mode().expect("failed to enable raw mode");
+        if reset_enabled {
+            RESET_ENABLED.store(true, Ordering::SeqCst);
+            debug!("raw mode enabled");
+        }
+    }
+}
+
+pub fn disable_raw_mode() {
+    crossterm::terminal::disable_raw_mode().expect("failed to disable raw mode");
+    debug!("raw mode disabled");
+}
+
+pub fn reset_terminal_state() {
+    if is_raw_mode() && RESET_ENABLED.load(Ordering::SeqCst) {
+        let mut stdout = std::io::stdout();
+
+        // fully reset the terminal state: ESC c
+        // then clear the terminal: ESC [ 2 J
+        stdout
+            .write("\x1bc\x1b[2J".as_bytes())
+            .expect("failed to queue reset command");
+
+        stdout.flush().expect("failed to flush reset commands");
+
+        RESET_ENABLED.store(false, Ordering::SeqCst);
+
+        debug!("terminal state reset");
+    }
+}
 
 /// Reads TerminalMode, and launches/cancels the TerminalEchoService / TerminalCrosstermService
 pub struct TerminalService {
@@ -53,31 +92,28 @@ impl Service for TerminalService {
             let mut service = ServiceLifeline::None;
 
             while let Some(mode) = rx.recv().await {
-                if mode == current_mode {
-                    continue;
+                // here we need to deal with a lot of terminal state.
+                // the spawned services hold stdin/stdout references, and have actor state.
+                // and the mode itself represents some state (the selected tab)
+
+                // if the mode discriminant has changed, we restart the service
+                // if the new mode is not strictly equal, we clear the terminal.
+
+                // this allows mode transitions (fuzzy to tab), as well as tab switches
+
+                let restart = discriminant(&current_mode) != discriminant(&mode);
+                let reset_terminal = mode != current_mode;
+
+                if reset_terminal && restart {
+                    drop(service);
+                    reset_terminal_state();
+                    Self::set_raw_mode(&mode);
+
+                    service = Self::spawn_service(&mode, &terminal_bus)?;
+                } else if reset_terminal {
+                    reset_terminal_state();
+                    Self::set_raw_mode(&mode);
                 }
-
-                drop(service);
-                reset_terminal_state();
-
-                service = match mode {
-                    TerminalMode::None => ServiceLifeline::None,
-                    TerminalMode::Echo(ref name) => {
-                        info!("TerminalService switching to echo mode for tab {}", name);
-
-                        let service = TerminalEchoService::spawn(&terminal_bus)?;
-                        ServiceLifeline::Echo(service)
-                    }
-                    TerminalMode::FuzzyFinder => {
-                        info!("TerminalService switching to fuzzy finder mode");
-
-                        let fuzzy_bus = FuzzyBus::default();
-                        let carrier = fuzzy_bus.carry_from(&terminal_bus)?;
-
-                        let service = FuzzyFinderService::spawn(&fuzzy_bus)?;
-                        ServiceLifeline::FuzzyFinder(service, carrier)
-                    }
-                };
 
                 current_mode = mode;
             }
@@ -90,5 +126,47 @@ impl Service for TerminalService {
             _terminal_mode,
             _terminal_event,
         })
+    }
+}
+
+impl TerminalService {
+    fn set_raw_mode(mode: &TerminalMode) {
+        match mode {
+            TerminalMode::Echo(_) => {
+                enable_raw_mode(true);
+            }
+            TerminalMode::FuzzyFinder => {
+                enable_raw_mode(false);
+            }
+            TerminalMode::None => {
+                disable_raw_mode();
+            }
+        }
+    }
+
+    fn spawn_service(
+        mode: &TerminalMode,
+        terminal_bus: &TerminalBus,
+    ) -> anyhow::Result<ServiceLifeline> {
+        let service = match mode {
+            TerminalMode::None => ServiceLifeline::None,
+            TerminalMode::Echo(ref name) => {
+                info!("TerminalService switching to echo mode for tab {}", name);
+
+                let service = TerminalEchoService::spawn(&terminal_bus)?;
+                ServiceLifeline::Echo(service)
+            }
+            TerminalMode::FuzzyFinder => {
+                info!("TerminalService switching to fuzzy finder mode");
+
+                let fuzzy_bus = FuzzyBus::default();
+                let carrier = fuzzy_bus.carry_from(&terminal_bus)?;
+
+                let service = FuzzyFinderService::spawn(&fuzzy_bus)?;
+                ServiceLifeline::FuzzyFinder(service, carrier)
+            }
+        };
+
+        Ok(service)
     }
 }

--- a/tab-command/src/service/terminal/fuzzy.rs
+++ b/tab-command/src/service/terminal/fuzzy.rs
@@ -22,8 +22,6 @@ use fuzzy_matcher::{skim::SkimMatcherV2, FuzzyMatcher};
 use tab_api::tab::normalize_name;
 use tokio::{stream::Stream, stream::StreamExt, sync::watch};
 
-use super::echo_mode::{enable_raw_mode, reset_terminal_state};
-
 /// Rows reserved by the UI for non-match items
 const RESERVED_ROWS: usize = 2;
 
@@ -570,9 +568,6 @@ impl FuzzyFinderService {
     }
 
     async fn output(mut rx: impl Receiver<FuzzyOutputEvent>) -> anyhow::Result<()> {
-        enable_raw_mode(false);
-        reset_terminal_state();
-
         let mut stdout = std::io::stdout();
 
         while let Some(state) = rx.recv().await {

--- a/tab-command/src/state/terminal.rs
+++ b/tab-command/src/state/terminal.rs
@@ -1,3 +1,5 @@
+use tab_api::tab::TabId;
+
 use crate::env::terminal_size;
 
 /// The client's view of the current terminal size
@@ -13,12 +15,14 @@ impl Default for TerminalSizeState {
 }
 
 /// The current terminal mode.
+/// This type is used to guarantee consistency of the terminal state.
+/// When the terminal mode is changed, the terminal state is fully reset.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum TerminalMode {
     /// No terminal program is active
     None,
     /// Terminal is in raw mode, capturing stdin, and forwarding raw stdout (for the given tab name)
-    Echo(String),
+    Echo(TabId),
     /// Terminal is in interactive finder mode, using Crossterm.
     FuzzyFinder,
 }


### PR DESCRIPTION
- Trigger Echo mode resets when a new TabId is selected.  This more consistently applies terminal resets (e.g. during retasks or fuzzy selections).
- Only respawn the Echo / Fuzzy services if the terminal mode discriminant changes.  This avoids re-initializing the stdin reference, which caused a bug where the first character typed after a retask did nothing.