### PR TITLE
filter more control sequences (polluting the terminal)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1326,9 +1326,9 @@ dependencies = [
 
 [[package]]
 name = "semver-parser"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ef146c2ad5e5f4b037cd6ce2ebb775401729b19a82040c1beac9d36c7d1428"
+checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
 dependencies = [
  "pest",
 ]

--- a/tab-daemon/src/service/pty/scrollback.rs
+++ b/tab-daemon/src/service/pty/scrollback.rs
@@ -75,7 +75,7 @@ impl ScrollbackManager {
         }
     }
 
-    /// Several ANSI escape sequences that should not be replayed   
+    /// Several ANSI escape sequences that should not be replayed
     pub fn ansi_filter() -> AnsiFilter {
         AnsiFilter::new(vec![
             // replace ESC [ 6n, Device Status Report

--- a/tab-daemon/src/service/pty/scrollback.rs
+++ b/tab-daemon/src/service/pty/scrollback.rs
@@ -90,6 +90,22 @@ impl ScrollbackManager {
                 .into_iter()
                 .copied()
                 .collect(),
+            // replace ESC [ ** c, Send Device Attributes (Primary DA)
+            //   similarly, this sequence results in the terminal emulator echoing characters
+            //   reference: https://www.xfree86.org/current/ctlseqs.html
+            "\x1b]\x00\x00c".as_bytes().into_iter().copied().collect(),
+            // replace ESC [ = 0 c, Send Device Attributes (Tertiary DA)
+            //   similarly, this sequence results in the terminal emulator echoing characters
+            //   reference: https://www.xfree86.org/current/ctlseqs.html
+            "\x1b]=0c".as_bytes().into_iter().copied().collect(),
+            // replace ESC [ > ** ; ** ; 0 c, Send Device Attributes (Secondary DA)
+            //   similarly, this sequence results in the terminal emulator echoing characters
+            //   reference: https://www.xfree86.org/current/ctlseqs.html
+            "\x1b]>\x00\x00;\x00\x00;0c"
+                .as_bytes()
+                .into_iter()
+                .copied()
+                .collect(),
         ])
     }
 


### PR DESCRIPTION
From the bash (Apple) terminal, I'd ~sometimes get:

```
[>1;95;0c
```

The filter works great! I don't see them any more in my local build.