### PR TITLE
Rebind `ESC` in the fuzzy finder to return to the previously selected tab

### DIFF
--- a/tab-command/src/bus/fuzzy.rs
+++ b/tab-command/src/bus/fuzzy.rs
@@ -1,10 +1,18 @@
 use postage::{broadcast, mpsc, watch};
 
 use crate::{
-    message::fuzzy::FuzzyEvent, message::fuzzy::FuzzySelection, message::fuzzy::FuzzyShutdown,
-    message::terminal::TerminalSend, message::terminal::TerminalShutdown, prelude::*,
-    state::fuzzy::FuzzyMatchState, state::fuzzy::FuzzyOutputEvent, state::fuzzy::FuzzyQueryState,
-    state::fuzzy::FuzzySelectState, state::fuzzy::FuzzyTabsState, state::workspace::WorkspaceState,
+    message::fuzzy::FuzzyEvent,
+    message::fuzzy::FuzzySelection,
+    message::fuzzy::FuzzyShutdown,
+    message::terminal::TerminalSend,
+    message::terminal::TerminalShutdown,
+    prelude::*,
+    state::fuzzy::FuzzyMatchState,
+    state::fuzzy::FuzzyOutputEvent,
+    state::fuzzy::FuzzyQueryState,
+    state::fuzzy::FuzzySelectState,
+    state::fuzzy::FuzzyTabsState,
+    state::{fuzzy::FuzzyEscapeState, workspace::WorkspaceState},
 };
 
 lifeline_bus!(pub struct FuzzyBus);
@@ -40,6 +48,8 @@ impl Message<FuzzyBus> for FuzzyOutputEvent {
 impl Message<FuzzyBus> for FuzzyShutdown {
     type Channel = mpsc::Sender<Self>;
 }
+
+impl Resource<FuzzyBus> for FuzzyEscapeState {}
 
 pub struct TerminalFuzzyCarrier {
     _recv: Lifeline,

--- a/tab-command/src/bus/main.rs
+++ b/tab-command/src/bus/main.rs
@@ -3,7 +3,7 @@ use crate::{
     message::tabs::TabRecv,
     message::terminal::TerminalRecv,
     state::tabs::ActiveTabsState,
-    state::workspace::WorkspaceState,
+    state::{tab::TabMetadataState, workspace::WorkspaceState},
 };
 use crate::{prelude::*, state::tab::TabState};
 use lifeline::prelude::*;
@@ -34,6 +34,10 @@ impl Message<MainBus> for TabRecv {
 }
 
 impl Message<MainBus> for TabState {
+    type Channel = watch::Sender<Self>;
+}
+
+impl Message<MainBus> for TabMetadataState {
     type Channel = watch::Sender<Self>;
 }
 

--- a/tab-command/src/service/main/select_tab.rs
+++ b/tab-command/src/service/main/select_tab.rs
@@ -28,8 +28,8 @@ impl Service for MainSelectTabService {
 
         let _run = Self::try_task("run", async move {
             while let Some(recv) = rx.recv().await {
-                if let MainRecv::SelectTab(name) = recv {
-                    Self::select_tab(name, &mut tx_tab).await?;
+                if let MainRecv::SelectTab(tab) = recv {
+                    Self::select_tab(tab, &mut tx_tab).await?;
                 }
             }
 

--- a/tab-command/src/service/terminal/echo_input.rs
+++ b/tab-command/src/service/terminal/echo_input.rs
@@ -85,7 +85,7 @@ impl Default for KeyBindings {
             bindings: vec![
                 KeyBinding {
                     action: Action::Disconnect,
-                    sequence: vec![0x14, 0x1b],
+                    sequence: vec![0x14, 0x03],
                 },
                 KeyBinding {
                     action: Action::SelectInteractive,

--- a/tab-command/src/state/fuzzy.rs
+++ b/tab-command/src/state/fuzzy.rs
@@ -1,8 +1,14 @@
 use std::sync::Arc;
 
+use lifeline::impl_storage_clone;
 use tab_api::tab::normalize_name;
 
 use super::workspace::{WorkspaceState, WorkspaceTab};
+
+#[derive(Debug, Clone, Default)]
+pub struct FuzzyEscapeState(pub Option<String>);
+impl_storage_clone!(FuzzyEscapeState);
+
 #[derive(Debug, Clone)]
 pub struct FuzzyTabsState {
     pub tabs: Arc<Vec<WorkspaceTab>>,

--- a/tab-command/src/state/tab.rs
+++ b/tab-command/src/state/tab.rs
@@ -25,6 +25,13 @@ pub enum TabState {
 }
 
 impl TabState {
+    pub fn as_id(&self) -> Option<TabId> {
+        if let TabState::Selected(id) = self {
+            return Some(*id);
+        }
+
+        None
+    }
     pub fn is_awaiting(&self, target_name: &str) -> bool {
         match self {
             TabState::None => false,

--- a/tab-command/src/state/terminal.rs
+++ b/tab-command/src/state/terminal.rs
@@ -23,8 +23,8 @@ pub enum TerminalMode {
     None,
     /// Terminal is in raw mode, capturing stdin, and forwarding raw stdout (for the given tab name)
     Echo(TabId),
-    /// Terminal is in interactive finder mode, using Crossterm.
-    FuzzyFinder,
+    /// Terminal is in interactive finder mode, using Crossterm.  ESC will navigate back to the provided tab.
+    FuzzyFinder(Option<String>),
 }
 
 impl Default for TerminalMode {

--- a/tab/tests/common/mod.rs
+++ b/tab/tests/common/mod.rs
@@ -193,7 +193,7 @@ impl TestCommand {
                             // write `ctrl-T ESC` to stdin
                             // this is a special escape sequence which users don't use
                             stdin
-                                .write_all(&[0x14, 0x1b])
+                                .write_all(&[0x14, 0x03])
                                 .await
                                 .expect("failed to write to stdin");
                             stdin.flush().await.expect("failed to flush stdin");

--- a/tab/tests/retask.rs
+++ b/tab/tests/retask.rs
@@ -18,7 +18,7 @@ async fn retask() -> anyhow::Result<()> {
         .await_stdout("echo target", 300)
         .await_stdout("$", 300)
         .complete_snapshot()
-        .stdin_bytes(&[0x14, 0x1b])
+        .disconnect()
         .run()
         .await?;
 


### PR DESCRIPTION
`ctrl-c` can now be used to quit the fuzzy finder.