### PR TITLE
Add 'fuzzy finder' retask support

### DIFF
--- a/common/tab-api/src/client.rs
+++ b/common/tab-api/src/client.rs
@@ -29,7 +29,7 @@ pub enum Request {
     ResizeTab(TabId, (u16, u16)),
 
     /// Re-tasks clients with the tabid selected to the given tab
-    Retask(TabId, TabId),
+    Retask(TabId, RetaskTarget),
 
     /// Terminates the shell on the given tab
     CloseTab(TabId),
@@ -39,6 +39,13 @@ pub enum Request {
 
     /// Shuts down all tab processes, including the daemon and all ptys
     GlobalShutdown,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub enum RetaskTarget {
+    Tab(TabId),
+    Disconnect,
+    SelectInteractive,
 }
 
 /// A response, sent from the daemon process to a connected CLI
@@ -51,7 +58,7 @@ pub enum Response {
     /// A notification that metadata about a running tab has changed.
     TabUpdate(TabMetadata),
     /// A notification that the client is being re-tasks, and will now be serving the user on another tab.
-    Retask(TabId),
+    Retask(RetaskTarget),
     /// A notification that the active tab has been terminated
     TabTerminated(TabId),
     /// A notification that the client should disconnect

--- a/tab-command/src/service/main.rs
+++ b/tab-command/src/service/main.rs
@@ -16,6 +16,7 @@ use crate::prelude::*;
 
 use lifeline::dyn_bus::DynBus;
 
+use tab_api::tab::TabId;
 use tab_websocket::{
     bus::{WebsocketCarrier, WebsocketConnectionBus},
     resource::connection::WebsocketResource,
@@ -105,4 +106,12 @@ impl Service for MainService {
     }
 }
 
-impl MainService {}
+pub fn env_tab_id() -> Option<TabId> {
+    if let Ok(id) = std::env::var("TAB_ID") {
+        if let Ok(id) = id.parse() {
+            return Some(TabId(id));
+        }
+    }
+
+    None
+}

--- a/tab-command/src/service/main/select_tab.rs
+++ b/tab-command/src/service/main/select_tab.rs
@@ -1,17 +1,9 @@
-use tab_api::tab::{normalize_name, TabId};
+use tab_api::tab::normalize_name;
 
 use crate::message::tabs::TabRecv;
 use crate::{message::main::MainRecv, prelude::*};
 
-pub fn env_tab_id() -> Option<TabId> {
-    if let Ok(id) = std::env::var("TAB_ID") {
-        if let Ok(id) = id.parse() {
-            return Some(TabId(id));
-        }
-    }
-
-    None
-}
+use super::env_tab_id;
 
 pub struct MainSelectTabService {
     _run: Lifeline,

--- a/tab-command/src/service/tab/select_tab.rs
+++ b/tab-command/src/service/tab/select_tab.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use anyhow::Context;
 use postage::watch;
-use tab_api::tab::TabId;
+use tab_api::{client::RetaskTarget, tab::TabId};
 use tokio::time;
 
 use crate::{
@@ -79,7 +79,7 @@ impl SelectTabService {
             }
 
             debug!("retask - sending retask to tab {}", id);
-            let request = Request::Retask(id, metadata.id);
+            let request = Request::Retask(id, RetaskTarget::Tab(metadata.id));
             tx_websocket.send(request).await?;
 
             // if we quit too early, the carrier is cancelled and our message doesn't get through.

--- a/tab-daemon/src/message/cli.rs
+++ b/tab-daemon/src/message/cli.rs
@@ -2,6 +2,7 @@ use super::tab::{TabOutput, TabScrollback};
 
 use tab_api::{
     chunk::{InputChunk, OutputChunk},
+    client::RetaskTarget,
     tab::{CreateTabMetadata, TabId, TabMetadata},
 };
 
@@ -20,7 +21,7 @@ pub enum CliSend {
     /// Creates a tab with the given metadata.  Ignored if a tab with the given name is already active.
     CreateTab(CreateTabMetadata),
     /// Requests that any clients who are subscribed to the given tab be retasked, to the second tab
-    Retask(TabId, TabId),
+    Retask(TabId, RetaskTarget),
     /// Requests the scrollback buffer be read, and replied to as a CliRecv::Scrollback message.
     Subscribe(TabId),
     /// Resizes the tab to the given number of (cols, rows)
@@ -63,7 +64,7 @@ pub enum CliSubscriptionRecv {
     Output(TabOutput),
     /// A notification that a tab has been retasked.  The client may need to request scrollback and change their subscriptions.
     /// If the second argument is None, the client should disconnect.
-    Retask(TabId, Option<TabId>),
+    Retask(TabId, RetaskTarget),
     /// Notification that a tab has stopped
     Stopped(TabId),
 }
@@ -72,8 +73,7 @@ pub enum CliSubscriptionRecv {
 /// Represented with the current state of the subscription, contains tab updates and output chunks
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CliSubscriptionSend {
-    Retask(TabId),
-    Disconnect,
+    Retask(RetaskTarget),
     Output(TabId, OutputChunk),
     Stopped(TabId),
 }

--- a/tab-daemon/src/message/tab.rs
+++ b/tab-daemon/src/message/tab.rs
@@ -2,6 +2,7 @@ use crate::state::{assignment::Assignment, pty::PtyScrollback};
 use std::sync::Arc;
 use tab_api::{
     chunk::{InputChunk, OutputChunk},
+    client::RetaskTarget,
     tab::{TabId, TabMetadata},
 };
 
@@ -68,7 +69,7 @@ pub enum TabRecv {
     Resize(TabId, (u16, u16)),
     /// Retasks all clients from the first tab, to the second
     /// If the second argument is None, then clients should disconnect
-    Retask(TabId, Option<TabId>),
+    Retask(TabId, RetaskTarget),
     Input(TabInput),
     Terminate(TabId),
     TerminateAll,
@@ -127,7 +128,7 @@ pub enum TabSend {
     Scrollback(TabScrollback),
     /// Instructs clients on the first tab to retask to the second
     /// If the second argument is None, clients should disconnect
-    Retask(TabId, Option<TabId>),
+    Retask(TabId, RetaskTarget),
     Output(TabOutput),
     Stopped(TabId),
 }

--- a/tab-daemon/src/service/daemon/retask.rs
+++ b/tab-daemon/src/service/daemon/retask.rs
@@ -37,7 +37,7 @@ mod tests {
     use super::RetaskService;
     use crate::{bus::ListenerBus, message::tab::TabRecv};
     use lifeline::{assert_completes, Bus, Receiver, Sender, Service};
-    use tab_api::tab::TabId;
+    use tab_api::{client::RetaskTarget, tab::TabId};
 
     #[tokio::test]
     async fn echo() -> anyhow::Result<()> {
@@ -47,11 +47,15 @@ mod tests {
         let mut tx = bus.tx::<TabRecv>()?;
         let mut rx = bus.rx::<TabRecv>()?;
 
-        tx.send(TabRecv::Retask(TabId(0), Some(TabId(1)))).await?;
+        tx.send(TabRecv::Retask(TabId(0), RetaskTarget::Tab(TabId(1))))
+            .await?;
 
         assert_completes!(async move {
             let msg = rx.recv().await;
-            assert_eq!(Some(TabRecv::Retask(TabId(0), Some(TabId(1)))), msg);
+            assert_eq!(
+                Some(TabRecv::Retask(TabId(0), RetaskTarget::Tab(TabId(1)))),
+                msg
+            );
         });
 
         Ok(())
@@ -65,11 +69,37 @@ mod tests {
         let mut tx = bus.tx::<TabRecv>()?;
         let mut rx = bus.rx::<TabRecv>()?;
 
-        tx.send(TabRecv::Retask(TabId(0), None)).await?;
+        tx.send(TabRecv::Retask(TabId(0), RetaskTarget::Disconnect))
+            .await?;
 
         assert_completes!(async move {
             let msg = rx.recv().await;
-            assert_eq!(Some(TabRecv::Retask(TabId(0), None)), msg);
+            assert_eq!(
+                Some(TabRecv::Retask(TabId(0), RetaskTarget::Disconnect)),
+                msg
+            );
+        });
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn echo_select_interactive() -> anyhow::Result<()> {
+        let bus = ListenerBus::default();
+        let _service = RetaskService::spawn(&bus);
+
+        let mut tx = bus.tx::<TabRecv>()?;
+        let mut rx = bus.rx::<TabRecv>()?;
+
+        tx.send(TabRecv::Retask(TabId(0), RetaskTarget::SelectInteractive))
+            .await?;
+
+        assert_completes!(async move {
+            let msg = rx.recv().await;
+            assert_eq!(
+                Some(TabRecv::Retask(TabId(0), RetaskTarget::SelectInteractive)),
+                msg
+            );
         });
 
         Ok(())

--- a/tab/tests/keyboard_latency.rs
+++ b/tab/tests/keyboard_latency.rs
@@ -16,7 +16,7 @@ async fn keyboard_latency() -> anyhow::Result<()> {
         .await_stdout("$", 3000)
         .stdin("!!")
         .await_stdout("!!", 5)
-        .stdin_bytes(&[0x14, 0x1b])
+        .disconnect()
         .run()
         .await?;
 


### PR DESCRIPTION
This PR allows users to execute `tab` with no arguments within a session.  The outer tab client will retask to the fuzzy finder.