### PR TITLE
Add `tab -` that selects the previous tab

### DIFF
--- a/tab-command/src/lib.rs
+++ b/tab-command/src/lib.rs
@@ -89,8 +89,13 @@ async fn main_async(matches: ArgMatches<'_>, tab_version: &'static str) -> anyho
         info!("CLI Match: ListTabs");
         tx.send(MainRecv::ListTabs).await?;
     } else if let Some(tab) = select_tab {
-        info!("CLI Match: SelectTab({})", &tab);
-        tx.send(MainRecv::SelectTab(tab.to_string())).await?;
+        if tab == "-" {
+            info!("CLI Match: SelectPreviousTab");
+            tx.send(MainRecv::SelectPreviousTab).await?;
+        } else {
+            info!("CLI Match: SelectTab({})", &tab);
+            tx.send(MainRecv::SelectTab(tab.to_string())).await?;
+        }
     } else if let Some(tabs) = close_tabs {
         info!("CLI Match: CloseTabs({:?})", &tabs);
         let tabs: Vec<String> = tabs.map(normalize_name).collect();

--- a/tab-command/src/message/main.rs
+++ b/tab-command/src/message/main.rs
@@ -22,6 +22,7 @@ pub enum MainRecv {
     GlobalShutdown,
     ListTabs,
     SelectInteractive,
+    SelectPreviousTab,
     SelectTab(String),
 }
 

--- a/tab-command/src/service/main.rs
+++ b/tab-command/src/service/main.rs
@@ -3,7 +3,8 @@ use self::{
     autocomplete_tab::MainAutocompleteTabsService, check_workspace::MainCheckWorkspaceService,
     close_tabs::MainCloseTabsService, disconnect_tabs::MainDisconnectTabsService,
     global_shutdown::MainGlobalShutdownService, list_tabs::MainListTabsService,
-    select_interactive::MainSelectInteractiveService, select_tab::MainSelectTabService,
+    select_interactive::MainSelectInteractiveService,
+    select_previous::MainSelectPreviousTabService, select_tab::MainSelectTabService,
 };
 
 use super::{
@@ -30,6 +31,7 @@ mod disconnect_tabs;
 mod global_shutdown;
 mod list_tabs;
 mod select_interactive;
+mod select_previous;
 mod select_tab;
 
 /// Launches the tab-command client, including websocket, tab state, and terminal services.
@@ -42,6 +44,7 @@ pub struct MainService {
     _main_global_shutdown: MainGlobalShutdownService,
     _main_list_tabs: MainListTabsService,
     _main_select_interactive: MainSelectInteractiveService,
+    _main_select_previous_tab: MainSelectPreviousTabService,
     _main_select_tab: MainSelectTabService,
     _main_tab: MainTabCarrier,
     _main_websocket: WebsocketCarrier,
@@ -67,6 +70,7 @@ impl Service for MainService {
         let _main_list_tabs = MainListTabsService::spawn(main_bus)?;
         let _main_select_interactive = MainSelectInteractiveService::spawn(main_bus)?;
         let _main_select_tab = MainSelectTabService::spawn(main_bus)?;
+        let _main_select_previous_tab = MainSelectPreviousTabService::spawn(main_bus)?;
 
         let tab_bus = TabBus::default();
 
@@ -93,6 +97,7 @@ impl Service for MainService {
             _main_global_shutdown,
             _main_list_tabs,
             _main_select_interactive,
+            _main_select_previous_tab,
             _main_select_tab,
             _main_tab,
             _main_websocket,

--- a/tab-command/src/service/main/select_previous.rs
+++ b/tab-command/src/service/main/select_previous.rs
@@ -1,0 +1,88 @@
+use postage::watch;
+use tab_api::tab::TabId;
+
+use crate::{
+    message::main::{MainRecv, MainShutdown},
+    prelude::*,
+    utils::await_state,
+};
+use crate::{message::tabs::TabRecv, state::tabs::ActiveTabsState};
+
+use super::env_tab_id;
+
+pub struct MainSelectPreviousTabService {
+    _run: Lifeline,
+}
+
+impl Service for MainSelectPreviousTabService {
+    type Bus = MainBus;
+    type Lifeline = anyhow::Result<Self>;
+
+    fn spawn(bus: &Self::Bus) -> Self::Lifeline {
+        let mut rx = bus.rx::<MainRecv>()?;
+        let mut rx_active = bus.rx::<Option<ActiveTabsState>>()?;
+
+        let mut tx_tab = bus.tx::<TabRecv>()?;
+        let mut tx_shutdown = bus.tx::<MainShutdown>()?;
+
+        let _run = Self::try_task("run", async move {
+            while let Some(recv) = rx.recv().await {
+                if let MainRecv::SelectPreviousTab = recv {
+                    Self::select_previous(&mut rx_active, &mut tx_tab, &mut tx_shutdown).await?;
+                }
+            }
+
+            Ok(())
+        });
+
+        Ok(Self { _run })
+    }
+}
+
+impl MainSelectPreviousTabService {
+    async fn select_previous(
+        mut rx_active_tabs: &mut watch::Receiver<Option<ActiveTabsState>>,
+        mut tx_tab: impl Sink<Item = TabRecv> + Unpin,
+        mut tx_shutdown: impl Sink<Item = MainShutdown> + Unpin,
+    ) -> anyhow::Result<()> {
+        info!("MainRecv::SelectPreviousTab running");
+        let env_tab = env_tab_id();
+        let state = await_state(&mut rx_active_tabs).await?;
+
+        if let Some(name) = Self::target(env_tab, state) {
+            let message = TabRecv::SelectNamedTab { name, env_tab };
+            tx_tab.send(message).await?;
+        } else {
+            println!("No tabs have been selected in the current session.");
+            tx_shutdown.send(MainShutdown(1)).await?;
+        }
+
+        Ok(())
+    }
+
+    fn target(selected: Option<TabId>, active: ActiveTabsState) -> Option<String> {
+        active
+            .tabs
+            .iter()
+            .fold(None, |prev, (id, metadata)| {
+                // ignore the currently selected tab
+                if selected == Some(*id) {
+                    return prev;
+                }
+
+                // otherwise, accept the tab if we have no match
+                if prev.is_none() {
+                    return Some(metadata);
+                }
+
+                // otherwise, if the metadata is newer than prev, accept it
+                if prev.unwrap().selected < metadata.selected {
+                    return Some(metadata);
+                }
+
+                // otherwise, return prev
+                prev
+            })
+            .map(|metadata| metadata.name.clone())
+    }
+}

--- a/tab/src/cli.rs
+++ b/tab/src/cli.rs
@@ -127,9 +127,18 @@ fn app() -> App<'static, 'static> {
                 .required(false)
                 .value_name("TAB")
                 .conflicts_with_all(&["CLOSE-TAB", "LIST", "SHUTDOWN"])
-                .validator(validate_tab_name)
+                .validator(validate_select_tab_name)
                 .index(1),
         )
+}
+
+/// We need to allow '-' for SelectPreviousTab
+fn validate_select_tab_name(name: String) -> Result<(), String> {
+    if name == "-" {
+        return Ok(());
+    }
+
+    validate_tab_name(name)
 }
 
 fn validate_tab_name(name: String) -> Result<(), String> {


### PR DESCRIPTION
When outside a session, it switches to the most recently selected tab:
```
$ tab foo
foo/ $ <disconnect>
$ tab -
foo/ $
```

When within a session, it switches to the previously selected tab
```
$ tab foo
foo/ $ tab bar
bar/ $ tab -
foo/ $
```