### PR TITLE
add --yes/-y to not confirm install

### DIFF
--- a/tab/src/cli.rs
+++ b/tab/src/cli.rs
@@ -62,6 +62,13 @@ fn app() -> App<'static, 'static> {
                 .help("Automatically installs completions & statusline integrations."),
         )
         .arg(
+            Arg::with_name("YES")
+                .long("yes")
+                .short("y")
+                .required(false)
+                .help("Do not confirm install."),
+        )
+        .arg(
             Arg::with_name("CHECK-WORKSPACE")
                 .long("check")
                 .short("-k")

--- a/tab/src/install.rs
+++ b/tab/src/install.rs
@@ -16,7 +16,7 @@ mod fish;
 mod starship;
 mod zsh;
 
-pub fn run<'a>(commands: Values<'a>) -> anyhow::Result<()> {
+pub fn run<'a>(commands: Values<'a>, yes: bool) -> anyhow::Result<()> {
     let env = PackageEnv::new()?;
 
     for command in commands {
@@ -42,7 +42,7 @@ pub fn run<'a>(commands: Values<'a>) -> anyhow::Result<()> {
             eprint!("{}", package.to_string());
         }
 
-        if !Confirm::new()
+        if !yes && !Confirm::new()
             .with_prompt("Do you wish to apply the modifications?")
             .interact()?
         {

--- a/tab/src/main.rs
+++ b/tab/src/main.rs
@@ -58,8 +58,12 @@ pub fn main() -> anyhow::Result<()> {
         print!("{}", histfile.to_string_lossy());
 
         Ok(())
-    } else if let Some(args) = args.values_of("INSTALL") {
-        install::run(args)
+    } else if let Some(install_args) = args.values_of("INSTALL") {
+        let mut yes = false;
+        if args.is_present("YES") {
+            yes = true;
+        }
+        install::run(install_args, yes)
     } else if args.is_present("STARSHIP") {
         // used for the starship prompt
         let tab = std::env::var("TAB");


### PR DESCRIPTION
closes #354 

The way the argument is added isn't ideal since the argument isn't properly limited to install, but it works. On the other hand it is possible that we may want to do a confirm for shutdown or some other command in the future.

I tested this and when I added `--yes` before `--install` it did not ask for confirmation. Without `--yes` it did ask for confirmation.