### PR TITLE
Fix directory parameter in example top-level config in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ workspace:
   # this is a global tab, that is always available, and initializes in ~/tab-dir
   - tab: global-tab
     doc: "my global tab doc"
-    directory: tab-dir
+    dir: tab-dir
 
   # this links to a workspace config in ~/my-workspace
   #   workspaces are only active within the workspace directory


### PR DESCRIPTION
Using `directory` silently does nothing, but `dir` works.